### PR TITLE
fix(position:css): gestion en position absolue du bouton "menu widget"

### DIFF
--- a/src/components/menu/MenuLateralWrapper.vue
+++ b/src/components/menu/MenuLateralWrapper.vue
@@ -134,5 +134,24 @@ left: 10px;
   position: absolute;
 }
 
+/* FIX ME : le bouton widget n'est pas intégré à la grille des widgets
+On gère donc sa position de manière absolue */
+@media (max-width: 382px) {
+  .menu-logo-list {
+    top : 308px;
+  }
+}
+
+@media (max-width: 576px) and (min-width: 382px){
+  .menu-logo-list {
+    top : 286px;
+  }
+}
+
+@media (max-width: 627px) and (min-width: 576px){
+  .menu-logo-list {
+    top : 228px;
+  }
+}
 
 </style>


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [ ] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [ ] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :
<!-- Décrire le comportement actuel qui est modifié, pourquoi il est modifié et, eventuellement, citer des tickets concernés -->

Le bouton "rouage" pour ouvrir le menu des widgets ne se positionne pas correctement sur petit écran : 
![image](https://github.com/user-attachments/assets/fafbd232-0b5f-412e-bd04-e41309a98022)




## Quel est le nouveau comportement :
<!-- Décrire le comportement ou les changements ajoutés par cette PR -->
Le bouton est désormais positionné de manière absolue selon 3 média query (3 seuils).

A terme, il serait pertinent d'intégrer ce bouton à la grille des widgets.

Seuil supérieur à 627px de large

![image](https://github.com/user-attachments/assets/91bf8905-711b-4242-a8f4-37d182478edf)

Seuil entre 576px et 627px de large

![image](https://github.com/user-attachments/assets/404e351d-8fe5-48f6-9724-65a685d11c86)

Seuil entre 382px et 576px de large

![image](https://github.com/user-attachments/assets/bd4c97b7-dbac-4466-8d95-04c4a7d9214f)

Seuil inférieur à  382px de large

![image](https://github.com/user-attachments/assets/b8a5f45b-e03d-4ca9-b5d6-4f9c679a6244)


## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

<!-- Autres informations importantes concernant cette PR comme la liste des tickets concernés, ou des screenshots qui illustrent les changements introduits par cette PR. -->
