### PR TITLE
Fix Recette : Réorganisation des boutons et des panels (menu, carto)

### DIFF
--- a/src/components/CartoAndTools.vue
+++ b/src/components/CartoAndTools.vue
@@ -91,4 +91,11 @@ const selectedControls = computed(() => {
     height: 70vh;
     display: flex;
   }
+
+  @media (max-width: 576px) {
+    #map-and-tools-container {
+      /* FIXME : la hauteur de la carto dépend de la hauteur du footer et du header, ici en dur */
+      height: calc(100vh - 92.5px - 56px);
+    }
+  }
 </style>

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -393,7 +393,7 @@ const mousePositionOptions = {
 @media (min-width: 576px) {
   .position-container-top-right,
   .position-container-top-left {
-    top: 56px;
+    top: 98px;
   }
 }
 @media (max-width: 576px) {
@@ -405,7 +405,7 @@ const mousePositionOptions = {
 @media (max-width: 627px) and (min-width: 576px){
   .position-container-top-right,
   .position-container-top-left {
-    top: 120px;
+    top: 164px;
   }
 }
 </style>

--- a/src/components/carte/control/Share.vue
+++ b/src/components/carte/control/Share.vue
@@ -172,7 +172,7 @@ onBeforeMount(() => {
   #share-button-position {
     position: absolute;
     left: 10px;
-    top: 225px;
+    top: 56px;
     z-index: 1000;
   }
   .share-button-size {
@@ -182,5 +182,19 @@ onBeforeMount(() => {
   }
   .share-iframe-input {
     height: 200px;
+  }
+
+  /* positionnement absolu à adapter en fonction du positionnement
+  des autres boutons car n'est pas dans la grille */
+  @media (max-width: 576px){
+    #share-button-position {
+      top: 60px;
+    }
+  }
+
+  @media (max-width: 627px) and (min-width: 576px){
+    #share-button-position {
+      top: 120px;
+    }
   }
 </style>

--- a/src/components/menu/MenuLateralWrapper.vue
+++ b/src/components/menu/MenuLateralWrapper.vue
@@ -142,7 +142,7 @@ En mode petit écran on le positione tout en haut en attendant mieux */
   }
 }
 
-@media (max-width: 576px) and (min-width: 382px){
+@media (max-width: 576px) and (min-width: 382px) {
   .menu-logo-list {
     margin-top: 13px;
   }
@@ -151,6 +151,31 @@ En mode petit écran on le positione tout en haut en attendant mieux */
 @media (max-width: 627px) and (min-width: 576px){
   .menu-logo-list {
     top : 228px;
+  }
+}
+
+/* Les panels de gestion des widgets et du catalogue prennent toute la largeur
+sur petits écrans (<627px de large) */
+@media (max-width: 627px) {
+  .menu-toggle-wrap {
+    z-index: 1001;
+    &.is_expanded {
+      .menu-content-list {
+        width: 100%;
+      }
+    }
+  }
+
+  .left {
+    .menu-content-list {
+      left: 0px;
+    }
+  }
+
+  .right {
+    .menu-content-list {
+      right: 0px;
+    }
   }
 }
 </style>

--- a/src/components/menu/MenuLateralWrapper.vue
+++ b/src/components/menu/MenuLateralWrapper.vue
@@ -134,16 +134,17 @@ left: 10px;
 }
 
 /* FIX ME : le bouton widget n'est pas intégré à la grille des widgets
-On gère donc sa position de manière absolue */
+On gère donc sa position de manière absolue
+En mode petit écran on le positione tout en haut en attendant mieux */
 @media (max-width: 382px) {
   .menu-logo-list {
-    top : 308px;
+    margin-top: 13px;
   }
 }
 
 @media (max-width: 576px) and (min-width: 382px){
   .menu-logo-list {
-    top : 286px;
+    margin-top: 13px;
   }
 }
 
@@ -152,5 +153,4 @@ On gère donc sa position de manière absolue */
     top : 228px;
   }
 }
-
 </style>

--- a/src/components/menu/MenuLateralWrapper.vue
+++ b/src/components/menu/MenuLateralWrapper.vue
@@ -34,30 +34,27 @@ defineExpose({
 })
 </script>
 
-
-
 <template>
-  <div 
-  class="menu-toggle-wrap" 
-  :class="`${is_expanded  && 'is_expanded'} ${props.side}`"
-  v-if="visibility"
+  <div
+    class="menu-toggle-wrap"
+    :class="`${is_expanded  && 'is_expanded'} ${props.side}`"
+    v-if="visibility"
   >
     <div ref="menuTabs" class="menu-logo-list">
       <slot name="navButtons"></slot>
     </div>
 
-  
     <div class="menu-content-list"
     v-show="is_expanded">
       <div class="menu-collapse-icon-wrapper">
-        <DsfrButton :id="id" 
+        <DsfrButton :id="id"
           tertiary
           no-outline
           class="menu-collapse-icon"
           @click="closeMenu">
           Fermer
           <VIcon
-        v-bind="iconProps"/>  
+        v-bind="iconProps"/>
         </DsfrButton>
       </div>
 
@@ -68,12 +65,10 @@ defineExpose({
   </div>
 </template>
 
-
-
 <style scoped lang="scss">
 .left {
   .menu-logo-list {
-left: 10px;
+    left: 10px;
   }
   .menu-content-list {
     left: 60px;
@@ -133,9 +128,9 @@ left: 10px;
   position: absolute;
 }
 
-/* FIX ME : le bouton widget n'est pas intégré à la grille des widgets
+/* FIXME : le bouton widget n'est pas intégré à la grille des widgets
 On gère donc sa position de manière absolue
-En mode petit écran on le positione tout en haut en attendant mieux */
+En mode petit écran on le positionne tout en haut en attendant mieux */
 @media (max-width: 382px) {
   .menu-logo-list {
     margin-top: 13px;
@@ -153,10 +148,20 @@ En mode petit écran on le positione tout en haut en attendant mieux */
     top : 228px;
   }
 }
-
-/* Les panels de gestion des widgets et du catalogue prennent toute la largeur
-sur petits écrans (<627px de large) */
+/* Petits écrans */
 @media (max-width: 627px) {
+  // FIXME : on cache les bouton "rouage" et "catalogue" si un menu latéral est ouvert.
+  // Cette instruction contourne le css scopé pour selectionner le menu suivant (tild) si le menu scopé est expanded
+  .menu-toggle-wrap.is_expanded ~ .menu-toggle-wrap > .menu-logo-list {
+    display : none;
+  }
+
+  // Cette instruction contourne le css scopé pour selectionner le menu scopé s'il y a un menu expanded après (tild)
+  .menu-toggle-wrap:has(~ .menu-toggle-wrap.is_expanded) > .menu-logo-list {
+    display: none
+  }
+  /* Les panels de gestion des widgets et du catalogue prennent toute la largeur
+  sur petits écrans (<627px de large) et passent au dessus du reste */
   .menu-toggle-wrap {
     z-index: 1001;
     &.is_expanded {


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [x] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [ ] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [ ] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## 1 - Organisation des boutons

### Avant PR : 
- Le bouton partage se situe sous les widgets de mesure, ce qui risque de poser problème si d'autres se rajoutent
![image](https://github.com/user-attachments/assets/16b52a1d-6de2-4431-948f-046e9f3b09c6)

- Sur petit écran, les boutons catalogue, rouage, partage, positionnés en dur, ne s'adaptent pas et se superposent aux widgets
![image](https://github.com/user-attachments/assets/1cded706-38b4-4865-8d6a-830757f23dc5)


### Après PR : 
- Le bouton partage se situe directement sous le bouton catalogue, en fixe. Les widgets s'ajoutent et s'empilent après 
![image](https://github.com/user-attachments/assets/03091813-80e5-42dc-b35f-d3a87021161d)

- Sur petit écran, les boutons catalogue, rouage, partage, sont repositionnés en dur au niveau de la barre de recherche
![image](https://github.com/user-attachments/assets/201723bc-54d6-4442-b586-03d1ef5053a0)

## 2 - Panels des menus "Widgets" et "Catalogue" sur petit écran

### Avant PR : 
Les panels s'affichent en dehors de la carte et sont inutilisables.

Catalogue : 
![image](https://github.com/user-attachments/assets/e0e50add-2bc0-4695-83cb-d07695623393)

Gestionnaire d'outils : 
![image](https://github.com/user-attachments/assets/fce8c702-2f04-4a6d-8d27-968462efbcf4)

### Après PR : 
Les panels s'affichent en plein écran et au dessus des autres éléments : 

Catalogue : 
![image](https://github.com/user-attachments/assets/7f0bb963-0dd3-4248-8a0d-dcc5e0b3efa5)

Gestionnaire d'outils : 
![image](https://github.com/user-attachments/assets/4f145082-62db-43a4-ab3c-ad6ea8274d26)

## 3 - Hauteur de la carto lorsque le footer est réduit sur petit écran

### Avant PR : 

Quand la taille du footer est réduit, la carto ne s'adapte pas en hauteur et peut laisser un blanc en pied de page :
![image](https://github.com/user-attachments/assets/8157f5eb-224e-4f75-acd3-7669a8afdf99)

Quand la taille du footer est réduit, la carto s'adapte en hauteur en fonction de la taille du header et du footer (en dur dans le css, voir dernier commit de cette PR, si vous trouvez mieux) :
![image](https://github.com/user-attachments/assets/c7159687-c4f0-4af6-88ae-0d792958e780)

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

<!-- Autres informations importantes concernant cette PR comme la liste des tickets concernés, ou des screenshots qui illustrent les changements introduits par cette PR. -->
