### PR TITLE
fix(datastore): Gestion des couches privées dans la barre de recherche

### DIFF
--- a/src/components/carte/Layer/Layer.vue
+++ b/src/components/carte/Layer/Layer.vue
@@ -47,6 +47,7 @@ onMounted(() => {
       layer.value = new GeoportalWMS({
         layer : name,
         configuration : value,
+        apiKey : "ign_scan_ws",
         olParams : Object.assign(options, preload)
       });
       break;
@@ -54,6 +55,7 @@ onMounted(() => {
       layer.value = new GeoportalWMTS({
         layer : name,
         configuration : value,
+        apiKey : "ign_scan_ws",
         olParams : Object.assign(options, preload)
       });
       break;
@@ -61,7 +63,8 @@ onMounted(() => {
       // INFO le style par defaut est utilisé !
       layer.value = new GeoportalMapBox({
         layer : name,
-        configuration : value
+        configuration : value,
+        apiKey : "ign_scan_ws",
       }, options);
       break;
     default:

--- a/src/stores/dataStore.js
+++ b/src/stores/dataStore.js
@@ -25,8 +25,7 @@ export const useDataStore = defineStore('data', () => {
   async function fetchData() {
     try {
 
-      const techUrl =
-        import.meta.env.VITE_GPF_CONF_TECH_URL || "data/layers.json";
+      const techUrl = "data/layers.json";
       const editoUrl =
         import.meta.env.VITE_GPF_CONF_EDITO_URL || "data/edito.json";
 


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [x] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [ ] Les tests (`npm run test`) sont passés localement


## Type de Pull request

Permet d'afficher les couches /private de la clé "ign_scan_ws" : 
- on tape sur layers.json du projet
- on a ajouté au layers.json la config json de la clé "ign_scan_ws" (issue de https://geoplateforme-configuration.onrender.com/)
- on a ajouté à l'instanciation des couches de l'entrée carto (Layer.vue) la clé "ign_scan_ws"

Mais solution non viaible, par exemple, la couche club Vosgien continue de s'afficher en résultat de l'autocomplétion mais ne peut être ajoutée car non présente pour la clé "ign_scan_ws"

## Autres informations
### **ATTENTION PR NON VALIDE EN L'ETAT.**

**Voir pour :** 
- ne pas taper sur le layers.json local
- utiliser une clé dédiée
- déterminer quelles couches private doivent être affichées

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :
Les couches en url private sont visibles en résultats de la barre de recherche mais ne peuvent être ajoutées


## Quel est le nouveau comportement :
<!-- Décrire le comportement ou les changements ajoutés par cette PR -->
Les couches en url private sont visibles en résultats de la barre de recherche et peuvent être ajoutées si elles sont autorisées par la clé "ign_scan_ws"

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->

