### PR TITLE
Ajout des options de filtres sur le widget SearchEngine

### DIFF
--- a/public/data/edito.json
+++ b/public/data/edito.json
@@ -100,6 +100,13 @@
     "opened": false,
     "version": 1
   },
+  "featured" : [
+    "CADASTRALPARCELS.PARCELLAIRE_EXPRESS",
+    "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
+    "PLAN.IGN",
+    "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",
+    "ORTHOIMAGERY.ORTHOPHOTOS"
+  ],
   "layers": {
     "CADASTRALPARCELS.PARCELLAIRE_EXPRESS$GEOPORTAIL:OGC:WMTS": {
       "thematic": "Foncier",

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -11,35 +11,36 @@
 </script>
 
 <script setup lang="js">
-import SearchEngine from './control/SearchEngine.vue'
-import ScaleLine from './control/ScaleLine.vue'
-import OverviewMap from './control/OverviewMap.vue'
-import Zoom from './control/Zoom.vue'
-import Attributions from './control/Attributions.vue'
-import LayerSwitcher from './control/LayerSwitcher.vue'
-import Legends from './control/Legends.vue'
-import Isocurve from './control/Isocurve.vue'
-import Route from './control/Route.vue'
-import MeasureLength from './control/MeasureLength.vue'
-import MeasureArea from './control/MeasureArea.vue'
-import MeasureAzimuth from './control/MeasureAzimuth.vue'
-import MousePosition from './control/MousePosition.vue'
-import ElevationPath from './control/ElevationPath.vue'
+import SearchEngine from './control/SearchEngine.vue';
+import ScaleLine from './control/ScaleLine.vue';
+import OverviewMap from './control/OverviewMap.vue';
+import Zoom from './control/Zoom.vue';
+import Attributions from './control/Attributions.vue';
+import LayerSwitcher from './control/LayerSwitcher.vue';
+import Legends from './control/Legends.vue';
+import Isocurve from './control/Isocurve.vue';
+import Route from './control/Route.vue';
+import MeasureLength from './control/MeasureLength.vue';
+import MeasureArea from './control/MeasureArea.vue';
+import MeasureAzimuth from './control/MeasureAzimuth.vue';
+import MousePosition from './control/MousePosition.vue';
+import ElevationPath from './control/ElevationPath.vue';
 import Territories from './control/Territories.vue';
-import GetFeatureInfo from './control/GetFeatureInfo.vue'
-import LayerImport from './control/LayerImport.vue'
+import GetFeatureInfo from './control/GetFeatureInfo.vue';
+import LayerImport from './control/LayerImport.vue';
 
-import Share from './control/Share.vue'
+import Share from './control/Share.vue';
 
 // Icone pour le marker du widget SearcEngine
 import IconGeolocationSVG from "../../assets/geolocation.svg";
 
-import { useControls } from '@/composables/controls'
-import { useLogger } from 'vue-logger-plugin'
+import { useDataStore } from '@/stores/dataStore';
+import { useControls } from '@/composables/controls';
+import { useLogger } from 'vue-logger-plugin';
 
 const props = defineProps({
   controlOptions: Array
-})
+});
 
 // INFO
 // liste des contrôles à activer
@@ -58,7 +59,8 @@ const props = defineProps({
 //  "FullScreen"
 //  (...)
 // ]
-const log = useLogger()
+const dataStore = useDataStore();
+const log = useLogger();
 log.debug(props.controlOptions);
 
 // liste des options pour les contrôles;
@@ -73,7 +75,7 @@ const territoriesOptions = {
   thumbnail : false, // imagette des territoires
   reduce : false, // tuiles reduites par defaut
   tiles : 3
-}
+};
 
 const layerSwitcherOptions = {
   options: {
@@ -82,19 +84,19 @@ const layerSwitcherOptions = {
     panel: true,
     counter: true
   }
-}
+};
 
 const legendsOptions = {
   position : "top-right",
   panel: true,
   auto: true,
   draggable: false
-}
+};
 
 const scaleLineOptions = {
   units: 'metric',
   bar: false,
-}
+};
 
 const searchEngineOptions = {
   collapsed: false,
@@ -109,57 +111,59 @@ const searchEngineOptions = {
   searchOptions: {
     addToMap: false,
     filterServices : "WMTS,WMS,TMS",
+    filterWMTSPriority : true,
+    filterLayersPriority : dataStore.getFeatured().toString(),
     serviceOptions: {}
   },
   markerUrl : IconGeolocationSVG
-}
+};
 
 const getFeatureInfoOptions = {
   position: 'bottom-left'
-}
+};
 
 const overviewMapOptions = {
   position: 'bottom-left'
-}
+};
 
 const zoomOptions = {
   position: 'bottom-right',
-}
+};
 
-const attributionsOptions = {}
+const attributionsOptions = {};
 
 const isocurveOptions = {
   position: 'bottom-right'
-}
+};
 
 const routeOptions = {
   position: 'bottom-right'
-}
+};
 
 const reverseGeocodeOptions = {
   position: 'bottom-right'
-}
+};
 
 const fullscreenOptions = {
   position: 'bottom-right'
-}
+};
 
 const measureLengthOptions = {
   position: 'top-left'
-}
+};
 const measureAreaOptions = {
   position: 'top-left'
-}
+};
 const measureAzimuthOptions = {
   position: 'top-left'
-}
+};
 const elevationPathOptions = {
   position: 'bottom-left'
-}
+};
 
 const layerImportOptions = {
   position: 'bottom-left'
-}
+};
 
 const mousePositionOptions = {
   position: 'bottom-left',
@@ -300,7 +304,7 @@ const mousePositionOptions = {
       geoBBox : { left: 156.25, bottom : -26.45, right : 174.28, top : -14.83 }
     }
   ]
-}
+};
 
 </script>
 <!-- INFO : Affichage du contrôle

--- a/src/stores/dataStore.js
+++ b/src/stores/dataStore.js
@@ -16,6 +16,7 @@ export const useDataStore = defineStore('data', () => {
   const m_tileMatrixSets = ref({});
   const m_contacts = ref({});
   const m_territories = ref([]);
+  const m_featured = ref([]);
   const isLoaded = ref(false);
   const error = ref("");
 
@@ -59,6 +60,7 @@ export const useDataStore = defineStore('data', () => {
       m_contacts.value = edito.contacts;
       m_informations.value = edito.informations;
       m_thematics.value = edito.thematics;
+      m_featured.value = edito.featured || [];
       m_layers.value = res;
       m_generalOptions.value = tech.generalOptions;
       m_tileMatrixSets.value = tech.tileMatrixSets;
@@ -87,6 +89,10 @@ export const useDataStore = defineStore('data', () => {
 
   function getThematics() {
     return m_thematics.value;
+  }
+
+  function getFeatured() {
+    return m_featured.value;
   }
 
   function getLayers() {
@@ -249,6 +255,7 @@ export const useDataStore = defineStore('data', () => {
     getContacts,
     getInformations,
     getThematics,
+    getFeatured,
     getLayers,
     getLayerKeysByID,
     getLayerIdByName,


### PR DESCRIPTION
Ajout des options sur le widget **SearchEngine**
```js
searchOptions: {
    addToMap: false,
    filterServices : "WMTS,WMS,TMS",
    filterWMTSPriority : true,
    filterLayersPriority : dataStore.getFeatured().toString(),
    serviceOptions: {}
  }
```
avec 

- `filterWMTSPriority` : https://github.com/IGNF/geopf-extensions-openlayers/issues/254
- `filterLayersPriority` permet de mettre en avant certaines couches sur la recherche, elles sont identifiées dans l'éditorial : 
```js
"featured" : [
    "CADASTRALPARCELS.PARCELLAIRE_EXPRESS",
    "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
    "PLAN.IGN",
    "LIMITES_ADMINISTRATIVES_EXPRESS.LATEST",
    "ORTHOIMAGERY.ORTHOPHOTOS"
  ]
```