### PR TITLE
Upgrade dsfr 1.11.2 --> 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "type-check": "vue-tsc --build --force"
   },
   "dependencies": {
-    "@gouvfr/dsfr": "^1.11.2",
+    "@gouvfr/dsfr": "^1.13.0",
     "@gouvminint/vue-dsfr": "^5.14.2",
     "@vueuse/components": "^10.9.0",
     "@vueuse/core": "^10.9.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ const isProduction = (import.meta.env.MODE === "production")
 const eulerian = createEulerian({
   verbose : !isProduction, // option du plugin
   domain: "acwg.cartes.gouv.fr", // OBLIGATOIRE :domaine de tracking Eulerian 
-  isActionEnabled: false, // on desactive le tracking global
+  isActionEnabled: "reduce", // on limite le tracking uniquement sur les elements "data-fr-analytics-action"
   site: {
     environment: isProduction ? "production" : "development",
     entity: "IGN"


### PR DESCRIPTION

* Upgrade dsfr 1.11.2 --> 1.13.0
* Test de performance sur l'API Analytic avec le correctif : https://github.com/GouvernementFR/dsfr/issues/1048

Les performances sur l'execution des scripts de l'API Analytic  me semble correct : 
![image](https://github.com/user-attachments/assets/ae1dbd0f-4c16-4f70-a49d-9653dd608d30)

Pour information : 
> l'upgrade dsfr n'impacte pas **VueDsfr** qui utilise une autre version
```bash
$ npm ls @gouvfr/dsfr
cartes.gouv.fr-entree-carto@1.0.0 /home/JPBazonnais/Projets/PORTAIL/cartes.gouv.fr-entree-carto
├── @gouvfr/dsfr@1.13.0
├─┬ @gouvminint/vue-dsfr@5.22.0
│ └── @gouvfr/dsfr@1.11.2
└─┬ geopf-extensions-openlayers@1.0.0-beta.0-291
  └── @gouvfr/dsfr@1.13.0 deduped
```
