### PR TITLE
fix(permalink): correction du #400, les widgets par defaut sont toujours ajoutés à la carte

### DIFF
--- a/src/composables/controls.js
+++ b/src/composables/controls.js
@@ -154,7 +154,7 @@ export function useDefaultControls() {
   var defaultControls = [];
   // récupération des controls par défaut
   for (var control in useControls) {
-    if (useControls[control].active === true) {
+    if (useControls[control].active === true && useControls[control].disable === true) {
       defaultControls.push(useControls[control].id);
     }
   }

--- a/src/composables/urlParams.js
+++ b/src/composables/urlParams.js
@@ -11,11 +11,8 @@ import {
  * - x / y : ...
  * - lon / lat : ...
  * - layers : ... 
+ * - controls : ...
  * - zoom : ...
- * - commentaire : "m" string avec contenu encodé
- * - titre : "t" string avec contenu encodé
- * - localisation : "g" boolean, ajout d'un icone
- * - informations : "i" boolean, ajout d'informations prédéfinies
  * 
  * @example
  * http://localhost:5173/cartes.gouv.fr-entree-carto/embed?
@@ -47,18 +44,8 @@ export function useUrlParams() {
           params.layers = urlParams[key];
           break;
         case "w":
-          // FIXME utile ? la liste devrait être fixe...
           params.controls = urlParams[key];
           break;
-        case "m":
-          console.debug("not yet implemented !");
-          break;
-        case "t":
-          console.debug("not yet implemented !");
-          break;
-        case "i":
-          console.debug("not yet implemented !");
-          break;  
         case "z":
           params.zoom = parseInt(urlParams[key], 10);
           break;

--- a/src/stores/mapStore.js
+++ b/src/stores/mapStore.js
@@ -23,13 +23,7 @@ const DEFAULT = {
   LAT: 50.800781249995744, // informatif
   ZOOM: 12,
   FIRSTVISIT: false,
-  NOINFORMATION: null,
-  PRINT: {
-    ICON: false,
-    INFO: false,
-    TITLE: "",
-    COMMENT: ""
-  }
+  NOINFORMATION: null
 }
 
 /**
@@ -76,7 +70,6 @@ const ns = ((value) => {
  *   et ',' pour chaque couches
  *   (!) pour le moment, on implemente tout simplement une liste des contrôles actifs !
  * 
- * @todo ordre des couches
  *
  */
 export const useMapStore = defineStore('map', () => {
@@ -114,10 +107,6 @@ export const useMapStore = defineStore('map', () => {
   var lat = useStorage(ns('lat'), DEFAULT.LAT);
   var firstVisit = useStorage(ns('firstVisit'), DEFAULT.FIRSTVISIT);
   var noInformation = useStorage(ns('noInformation'), DEFAULT.NOINFORMATION);
-  var title = useStorage(ns('print.title'), DEFAULT.PRINT.TITLE);
-  var comment = useStorage(ns('print.comment'), DEFAULT.PRINT.COMMENT);
-  var info = useStorage(ns('print.info'), DEFAULT.PRINT.INFO);
-  var geolocation = useStorage(ns('print.geolocation'), DEFAULT.PRINT.ICON);
 
   //////////////////
   // objets calculés
@@ -138,7 +127,7 @@ export const useMapStore = defineStore('map', () => {
     var last = location.pathname.slice(-1);
     var path = (last === "/") ? location.pathname.slice(0, -1) : location.pathname;
     var url = location.origin + (path.includes("/embed") ? path : path + "/embed");
-    return `${url}?c=${center.value}&z=${Math.round(zoom.value)}&l=${layers.value}&m=${comment.value}&i=${info.value}&t=${title.value}&g=${geolocation.value}&permalink=yes`;
+    return `${url}?c=${center.value}&z=${Math.round(zoom.value)}&l=${layers.value}&permalink=yes`;
   });
 
   var center = computed(() => {
@@ -215,18 +204,6 @@ export const useMapStore = defineStore('map', () => {
   })
   watch(controls, () => {
     localStorage.setItem(ns('controls'), controls.value.toString()); // string
-  })
-  watch(title, () => {
-    localStorage.setItem(ns('print.title'), title.value.toString()); // string
-  })
-  watch(comment, () => {
-    localStorage.setItem(ns('print.comment'), comment.value.toString()); // string
-  })
-  watch(info, () => {
-    localStorage.setItem(ns('print.info'), info.value); // boolean
-  })
-  watch(geolocation, () => {
-    localStorage.setItem(ns('print.geolocation'), icon.value); // boolean
   })
 
   //////////////////
@@ -349,10 +326,6 @@ export const useMapStore = defineStore('map', () => {
     lat,
     firstVisit,
     noInformation,
-    title,
-    comment,
-    info,
-    geolocation,
     permalink,
     permalinkShare,
     getMap,

--- a/src/stores/mapStore.js
+++ b/src/stores/mapStore.js
@@ -87,8 +87,17 @@ export const useMapStore = defineStore('map', () => {
 
   // gestion des KVP dans l'URL (permalink)
   var params = useUrlParams();
+  var defaultControls = DEFAULT.CONTROLS.split(",");
   for (const key in params) {
     if (Object.prototype.hasOwnProperty.call(params, key)) {
+      if (key === "controls") {
+        var myControls = params[key].split(",");
+        defaultControls.forEach(function(defaultControl) {
+          if (!myControls.includes(defaultControl)) {
+            params[key] = params[key] + "," + defaultControl;
+          }
+        })
+      }
       const value = params[key];
       localStorage.setItem(ns(key), value);
     }


### PR DESCRIPTION
On garde les widgets par défaut dans le permalien mais si on édite le permalien pour les retirer, ils sont quand même affichés

## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [ ] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [ ] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :

Les widgets par défaut ne sont pas bien gérés : on peut charger une interface sans eux si on édite un permalien


## Quel est le nouveau comportement :

Les widgets par défaut sont toujours présents sur la carte.

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

Fix #400 
