### PR TITLE
fix(search): lateral btn over autocomp results (mobile)

### DIFF
--- a/src/components/menu/MenuLateralWrapper.vue
+++ b/src/components/menu/MenuLateralWrapper.vue
@@ -197,17 +197,22 @@ En mode petit écran on le positionne tout en haut en attendant mieux */
   }
 }
 /* Petits écrans */
+@media (max-width: 576px) {
+  // FIXME : on cache les bouton "rouage" et "catalogue" si les résultats d'autocompletion sont affichés.
+  #mainMap:has(.GPautoCompleteList.GPelementVisible) ~ .menu-toggle-wrap > .menu-logo-list,
+  .menu-toggle-wrap:has(~ #mainMap .GPautoCompleteList.GPelementVisible) > .menu-logo-list {
+    display : none;
+  }
+}
+
 @media (max-width: 627px) {
   // FIXME : on cache les bouton "rouage" et "catalogue" si un menu latéral est ouvert.
   // Cette instruction contourne le css scopé pour selectionner le menu suivant (tild) si le menu scopé est expanded
+  .menu-toggle-wrap:has(~ .menu-toggle-wrap.is_expanded) > .menu-logo-list
   .menu-toggle-wrap.is_expanded ~ .menu-toggle-wrap > .menu-logo-list {
     display : none;
   }
 
-  // Cette instruction contourne le css scopé pour selectionner le menu scopé s'il y a un menu expanded après (tild)
-  .menu-toggle-wrap:has(~ .menu-toggle-wrap.is_expanded) > .menu-logo-list {
-    display: none
-  }
   /* Les panels de gestion des widgets et du catalogue prennent toute la largeur
   sur petits écrans (<627px de large) et passent au dessus du reste */
   .menu-toggle-wrap {


### PR DESCRIPTION
cf https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/444

avant
![398396967-1ecb0c74-fe1b-4439-96e8-963cf67c80b7](https://github.com/user-attachments/assets/13441b1b-0799-461f-99e9-0e0f5a30d476)

après
![image](https://github.com/user-attachments/assets/5909278f-be87-4e87-add1-5abbeaf93cde)
