### PR TITLE
💄 🌟 modif du bouton copier selon maquette UX

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -24,6 +24,7 @@ Rafraichissement forcé du LocalStorage (paramètres de la carte stockés dans l
 - Mise en cohérence des couches renvoyées par le moteur de recherche avec celles disponibles dans l'outil catalogue [#483](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/483)[#498](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/498)
 - Changement du nom du menu supérieur-droit : Menu carte s'affiche désormais dans la tooltip au survol [#485](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/485)
 - Barre de recherche : résultats "Lieux et adresses" et "Cartes et données" s'affichent sur la même fenêtre de résultats [ext-gpf-#346](https://github.com/IGNF/geopf-extensions-openlayers/pull/346)
+- Mise en conformité avec la maquette du copier-coller (https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/479)
 
 #### 🔥 [Obsolète]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -1,18 +1,12 @@
 # Unreleased
 
-<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.4...HEAD>
+<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.5...HEAD>
 
-## 🔖 version 1.0.4 - __DATE__
+## 🔖 version 1.0.5 - __DATE__
 
 ### 🎉 Résumé
 
-Amélioration de la barre de recherche principale.
-Mise à jour de la dépendance au framework VueDsfr. 
-Amélioration du processus de recherche de couches et de mise à jour du catalogue de l'entrée cartographique.
-
 ### 💥 Breaking changes
-
-Rafraichissement forcé du LocalStorage (paramètres de la carte stockés dans la session du navigateur).
 
 ### 📖 Changelog
 
@@ -20,10 +14,6 @@ Rafraichissement forcé du LocalStorage (paramètres de la carte stockés dans l
 
 #### 🔨 [Evolution]
 
-- Upgrade version vue-dsfr : vers 8.1.1 [#478](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/478)
-- Mise en cohérence des couches renvoyées par le moteur de recherche avec celles disponibles dans l'outil catalogue [#483](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/483)[#498](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/498)
-- Changement du nom du menu supérieur-droit : Menu carte s'affiche désormais dans la tooltip au survol [#485](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/485)
-- Barre de recherche : résultats "Lieux et adresses" et "Cartes et données" s'affichent sur la même fenêtre de résultats [ext-gpf-#346](https://github.com/IGNF/geopf-extensions-openlayers/pull/346)
 - Mise en conformité avec la maquette du copier-coller (https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/479)
 
 #### 🔥 [Obsolète]
@@ -31,13 +21,6 @@ Rafraichissement forcé du LocalStorage (paramètres de la carte stockés dans l
 #### 🔥 [Suppression]
 
 #### 🐛 [Correction]
-
-- Mise à jour automatique du catalogue de couches [481](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/481)
-- Amélioration des performances de recherche de l'outil de catalogue et filtrage des couches listées [#489](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/489)
-- Correction graphique de la hauteur du catalogue qui pouvait parfois dépasser en hauteur sur le footer [#484](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/484)
-- Correction graphique de la hauteur du panel de recherche avancée par parcelle qui pouvait dépasser sur le footer [#488](https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/488)
-- Filtrage de certaines propriétés de style (ex. label-stroke) pour qu'elles ne soient plus affichées dans la fenêtre d'affichage des attributions au clic (getFeatureInfo) [ext-gpf-357](https://github.com/IGNF/geopf-extensions-openlayers/pull/357)
-- Correction de la taille des fenêtres pour afficher les résultats d'import de services ou d'autocomplétion [ext-gpf-#349](https://github.com/IGNF/geopf-extensions-openlayers/pull/349)
 
 #### 🔒 [Sécurité]
 

--- a/env/.env.stage
+++ b/env/.env.stage
@@ -1,0 +1,27 @@
+VITE_GPF_CONF_TECH_URL="data/layers.json"
+VITE_GPF_CONF_PRIVATE_URL="data/private.json"
+VITE_GPF_CONF_EDITO_URL="https://data.geopf.fr/annexes/cartes.gouv.fr-config/public/edito.json"
+VITE_GPF_BASE_URL_EXTERNAL="http://localhost:9092" # cartes.gouv.fr installé via docker
+
+VITE_HTTP_MOCK_REQUEST=1
+VITE_HTTP_MOCK_REQUEST_SCENARIO="success_data" # success_nodata|success_data|error
+
+VITE_API_URL="https://data.geopf.fr/api"
+
+# désactivation de l'interface de connexion (1=désactivé)
+IAM_DISABLE=0
+
+IAM_URL="https://sso.geopf.fr"
+IAM_REALM="geoplateforme"
+IAM_CLIENT_ID="cartes-gouv-fr-carto"
+IAM_CLIENT_SECRET="GLGe8lcjSj7OytvAeHXABrZRFjbu31ny"
+# Mode auth local ou remote (distant)
+#   la redirection est vide en mode auth local,
+#   sinon en mode auth distant, on doit renseigner l'URL
+#   par ex. https://cartes.gouv.fr/login/entree-carto
+IAM_AUTH_MODE="local" # local|remote
+IAM_REDIRECT_REMOTE="http://localhost:9092/login/entree-carto"
+IAM_CLIENT_ID_REMOTE=
+IAM_CLIENT_SECRET_REMOTE=
+
+BASE_URL="/cartes.gouv.fr-entree-carto"

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -77,6 +77,7 @@ declare module 'vue' {
     ShareModal: typeof import('./components/carte/control/ShareModal.vue')['default']
     StoreData: typeof import('./components/StoreData.vue')['default']
     Territories: typeof import('./components/carte/control/Territories.vue')['default']
+    TextCopyToClipboard: typeof import('./components/utils/TextCopyToClipboard.vue')['default']
     VIcon: typeof import('oh-vue-icons')['OhVueIcon']
     View: typeof import('./components/carte/View.vue')['default']
     Zoom: typeof import('./components/carte/control/Zoom.vue')['default']

--- a/src/components/carte/control/ShareModal.vue
+++ b/src/components/carte/control/ShareModal.vue
@@ -14,8 +14,7 @@ export default {};
 import { useDataStore }  from '@/stores/dataStore';
 import { useMapStore }  from '@/stores/mapStore';
 import { useEulerian } from '@/plugins/Eulerian.js';
-import { useClipboard } from '@vueuse/core'
-import { VIcon } from '@gouvminint/vue-dsfr'
+import TextCopyToClipboard from '@/components/utils/TextCopyToClipboard.vue'
 
 const eulerian = useEulerian();
 const dataStore = useDataStore();
@@ -89,17 +88,8 @@ const iframe = computed(() => {
     allowfullscreen>
   </iframe>`;
 });
-const clipboardSource = ref('')
-const { text, copy, copied, isSupported } = useClipboard({ clipboardSource })
 
 const target = ref(null);
-
-const icon = "cil:copy"
-const defaultScale = ref(0.8325);
-const iconProps = computed(() => typeof icon === 'string'
-  ? { scale: defaultScale.value, name: icon }
-  : { scale: defaultScale.value, ...icon },
-);
 
 onMounted(() => {
   nextTick(function () {
@@ -147,14 +137,11 @@ defineExpose({
             descriptionId=""
           >
           <template #label>
-            Lien permanent vers la carte
-            <DsfrButton
-            tertiary
-            :noOutline="true"
-            @click="copy(mapStore.permalink)">
-            <VIcon
-            v-bind="iconProps"/>
-          </DsfrButton>
+            <TextCopyToClipboard
+              :copiedText="mapStore.permalink"
+              label="Lien permanent"
+              description="Toute personne ayant ce lien peut visualiser votre carte sans avoir à se créer de compte."
+            />
           </template>
           </DsfrInput>
         </p>
@@ -169,14 +156,11 @@ defineExpose({
             style="height: 200px;"
           >
           <template #label>
-            Copiez le code HTML pour intégrer la carte dans un site
-            <DsfrButton
-            tertiary
-            :noOutline="true"
-            @click="copy(iframe)">
-            <VIcon
-            v-bind="iconProps"/>
-          </DsfrButton>
+            <TextCopyToClipboard
+              :copiedText="iframe"
+              label="Iframe"
+              description="Insérer directement dans vos mails,  Réseaux sociaux ..."
+            />
           </template>
           </DsfrInput>
         </p>

--- a/src/components/utils/TextCopyToClipboard.vue
+++ b/src/components/utils/TextCopyToClipboard.vue
@@ -1,0 +1,83 @@
+<script lang="js">
+/**
+ * @description
+ * Panneau de partage de carte
+ *
+ * {@link https://github.com/dnum-mi/vue-dsfr/tree/main/src/components/DsfrButton}
+ * {@link https://github.com/dnum-mi/vue-dsfr/tree/main/src/components/DsfrModal}
+ * {@link https://github.com/dnum-mi/vue-dsfr/tree/main/src/components/DsfrShare}
+ */
+export default {};
+</script>
+
+<script lang="js" setup>
+import { useClipboard } from '@vueuse/core'
+import { VIcon } from '@gouvminint/vue-dsfr'
+import { useMatchMedia } from '@/composables/matchMedia';
+
+const isSmallScreen = useMatchMedia('SM')
+
+const props = defineProps({
+  copiedText: String,
+  label: String,
+  description : String
+});
+const clipboardSource = ref('')
+const { text, copy, copied, isSupported } = useClipboard({ clipboardSource })
+
+
+const iconBeforeCopy = "ri:file-copy-line"
+const iconAfterCopy = "ic:outline-check"
+
+const BtnLabelBeforeCopy = "Copier"
+const BtnLabelAfterCopy = "Copié"
+
+const icon = ref(iconBeforeCopy)
+const BtnLabel = ref(BtnLabelBeforeCopy)
+const defaultScale = ref(0.8325);
+const iconProps = computed(() => typeof icon.value === 'string'
+  ? { scale: defaultScale.value, name: icon.value }
+  : { scale: defaultScale.value, ...icon.value },
+);
+
+function copyAction() {
+    copy(props.copiedText)
+    icon.value = iconAfterCopy
+    BtnLabel.value = BtnLabelAfterCopy
+    setTimeout(() => {
+        icon.value = iconBeforeCopy
+        BtnLabel.value = BtnLabelBeforeCopy
+    }, 5000)
+}
+
+
+onMounted(() => {
+
+})
+</script>
+
+<template>
+    <div>
+        <div class="title-copy">
+            <div>{{ label }}</div>            
+            <DsfrButton
+                secondary
+                iconRight
+                :iconOnly="isSmallScreen"
+                :icon="iconProps"
+                @click="copyAction()">
+                {{ BtnLabel }}
+            </DsfrButton>
+            </div>
+        <p class="fr-hint-text hint-class">{{ description }}</p>            
+    </div>    
+</template>
+
+<style scoped>
+.title-copy {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+</style>


### PR DESCRIPTION
https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/479

100% front vérifier que la maquette ci dessous correspond. 
Attention
- interaction avec utilisateur après clic
- mode mobile

https://www.figma.com/design/Of9KQG60fBZPefncMuWL1j/Composants-suppl%C3%A9mentaires?node-id=2003-569&t=7g23PgjoYOMhWjlG-0

