### PR TITLE
Gestion du permalien avec les favoris

### DIFF
--- a/src/stores/dataStore.js
+++ b/src/stores/dataStore.js
@@ -56,19 +56,22 @@ export const useDataStore = defineStore('data', () => {
         ...editoWithTech
       }; // merge
       // ajoute la clé aux props
-      Object.keys(res).map((key) => { 
-        if(filterServices.split(",").some(service => res[key].serviceParams.id.includes(service))
-          && !filterProjections.split(",").some(proj => res[key].defaultProjection.includes(proj)))
+      Object.keys(res).map((key) => {
+        if (!res[key]) {
+          return
+        }
+        if(res[key].serviceParams && 
+          filterServices.split(",").some(service => res[key].serviceParams.id.includes(service)) && 
+          !filterProjections.split(",").some(proj => res[key].defaultProjection.includes(proj)))
         {
           res[key].key = key;
           let ret = {};
           ret[key] = res[key];
           return ret;
-      }
-      else  {
-        delete res[key];
-      }
-      })
+        } else  {
+          delete res[key];
+        }
+      });
 
       m_territories.value = edito.territories;
       m_contacts.value = edito.contacts;


### PR DESCRIPTION
# Gestion du permalien avec des données de l'espace personnel

## Analyse à faire

> - specif sur le permalien
> -  l'url public
> -  Short UUID

## TodoList

* [ ] Implémenter l'API Entrepôt : le partage public

:question: Ceci permet d'autoriser le partage et obtenir une url public
mais, est il facile de construire l'url à partir d'un UUID ?

* [ ] Utiliser le Short UUID pour le partage dans le permalien

:question:  Pour le passage d'un UUID vers Short UUID afin de simplifier l'URL
soit on extrait le dernier groupe de chiffre du UUID
ou soit on utilise une lib (short-uuid)
La réversibilité de la lib short-uuid semble une bonne façon de faire !

* [ ] Ajouter les données utilisateurs dans le permalien : croquis et imports (vecteurs)

:question:  On transforme le UUID en Short UUID
on l'ajoute dans le permalien
spécification du permalien à définir ?

* [ ] Lire les données utilisateurs dans le permalien

:question:  On transforme le Short UUID en UUID : la réversibilité semble possible avec short-uuid
soit on recherche le document avec l'UUID, puis on réalise une requête à l'API Entrepôt pour télécharger le document
soit l'url public est facile à construire à partir du UUID, donc pas de besoin de lancer une requête

* [ ] **BUG** : l'ordre des couches sur la lecture du permalien

:question: Ajouter la position dans le permalien permet de gérer l'ordre
voir comment le **LayerSwitcher** peut réarranger une liste de couche avec la position (zindex) ?


## Short UUID

cf. https://www.npmjs.com/package/short-uuid

La taille de la chaine semble aussi long qu'un UUID de l'entrepôt...

## Url public

cf. https://geoplateforme.github.io/tutoriels/production/complement/documents/partage/

La documentation dit : 
> Une URL publique a été générée aléatoirement, une extension en accord avec le type de fichier a été mise.

Si aléatoire, ça semble difficile de la déterminer par construction...

## Spécification du permalien

Exemple de permalien
> `http://localhost:5174/cartes.gouv.fr-entree-carto?c=2.5479878714752027,50.800781249995744&z=12&l=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS(1;1;0)&w=OverviewMap,SearchEngine,ScaleLine,LayerSwitcher,GetFeatureInfo,Legends,Zoom,FullScreen,Share,Print,Territories,LayerImport,ControlList,ContextMenu&permalink=yes`

La structure d'une couche
> `LAYERID(opacity<number>;visible<boolean>;gray<boolean>)<Array>`
     ex. ORTHOIMAGERY.ORTHOPHOTOS$GEOPORTAIL:OGC:WMTS(1;1;0)
     avec caractére de séparation des options de la liste : ';'
     et ',' pour chaque couches

Les couches du catalogues sont ajoutées dans le paramètre : **l**
> Ex. `l=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2$GEOPORTAIL:OGC:WMTS(1;1;0),500k$GEOPORTAIL:OGC:WMTS(1;1;0),BDCARTO_ETAT-MAJOR.NIVEAU3$GEOPORTAIL:OGC:WMTS(1;1;0)`

Les données utilisateurs enregistrées dans l'espace personnel sont ajoutées dans le paramètre : **d**
Ce sont des UUID ou des Short UUID avec les même caractéristiques qu'une couche : 
> `UUID(opacity<number>;visible<boolean>;gray<boolean>)<Array>`

:warning: Pour résoudre le problème de l'ordre des données dans le gestionnaire de couche, on va y ajouter la notion de **position** : 
> `DATA(opacity<number>;visible<boolean>;gray<boolean>,position>number>)<Array>`