### PR TITLE
feat(compute/drawing): activation des boutons d'export

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 Résumé
 
+Ajout d'une fonctionnalité pour exporter sur son ordinateur au format souhaité ses dessins, itinéraires, isochrones, profils altimétriques.
 La recherche par coordonnées est désormais accessible via la recherche avancée.
 Le widget Catalogue ("Cartalogue") tri désormais les sections et le titre des couches par ordre alphabétique. La description des couches peut être rendue visible en cliquant sur un bouton "Afficher plus".
 Les résultats de calcul d'itinéraire sont affichés de manière plus lisible.
@@ -16,9 +17,11 @@ Les résultats de calcul d'itinéraire sont affichés de manière plus lisible.
 
 #### ✨ [Ajout]
 
+  - Croquis et calculs : Ajout d'un bouton pour exporter ses créations de type croquis ou calcul (#509)
+
 #### 🔨 [Evolution]
 
-  - Mise en conformité avec la maquette du copier-coller (#479)
+  - Partage : Mise en conformité avec la maquette du bouton copier-coller (#479)
   - Cartalogue : tri par ordre alphabétique des couches selon le thème et le producteur (#503)
   - Cartalogue : description des couches cachée, ajout d'un bouton "Afficher plus" pour la voir (#507)
   - Recherche : la recherche par coordonnées est intégrée à la recherche avancée (#508)

--- a/src/components/carte/control/Drawing.vue
+++ b/src/components/carte/control/Drawing.vue
@@ -70,13 +70,13 @@ onMounted(() => {
   if (props.visibility) {
     map.addControl(drawing.value);
     map.addControl(btnExport.value);
-    map.addControl(btnSave.value);
+    // map.addControl(btnSave.value);
     if (props.analytic) {
       var el = drawing.value.element.querySelector("button[id^=GPshowDrawingPicto-]");
       useActionButtonEulerian(el);
     }
     /** abonnement au widget */
-    btnSave.value.on("button:clicked", onSaveVector);
+    // btnSave.value.on("button:clicked", onSaveVector);
     btnExport.value.on("button:clicked", onExportVector);
     drawing.value.on("change:collapsed", onToggleShowVector);
   }
@@ -86,18 +86,18 @@ onBeforeUpdate(() => {
   if (props.visibility) {
     map.addControl(drawing.value);
     map.addControl(btnExport.value);
-    map.addControl(btnSave.value);
+    // map.addControl(btnSave.value);
     if (props.analytic) {
       var el = drawing.value.element.querySelector("button[id^=GPshowDrawingPicto-]");
       useActionButtonEulerian(el);
     }
     /** abonnement au widget */
-    btnSave.value.on("button:clicked", onSaveVector);
+    // btnSave.value.on("button:clicked", onSaveVector);
     btnExport.value.on("button:clicked", onExportVector);
     drawing.value.on("change:collapsed",onToggleShowVector);
   }
   else {
-    map.removeControl(btnSave.value);
+    // map.removeControl(btnSave.value);
     map.removeControl(drawing.value);
     map.removeControl(btnExport.value);
   }
@@ -131,7 +131,7 @@ emitter.addEventListener("vector:edit:clicked", (e) => {
       format = "kml"; // par defaut ?
     }
     btnExport.value.setFormat(format);
-    btnSave.value.setFormat(format);
+    // btnSave.value.setFormat(format);
   }
 });
 

--- a/src/components/carte/control/Drawing.vue
+++ b/src/components/carte/control/Drawing.vue
@@ -30,7 +30,7 @@ const drawing = ref(new Drawing(props.drawingOptions));
 // bouton d'enregistrement / export du croquis avec un menu
 const btnExport = ref(new ButtonExport({
   title : "Exporter",
-  kind : "secondary",
+  kind : "primary",
   download : true,
   name: "Mon croquis",
   description: "",
@@ -49,6 +49,7 @@ const btnExport = ref(new ButtonExport({
     button : "export"
   }
 }));
+/*
 const btnSave = ref(new ButtonExport({
   title : "Enregistrer",
   kind : "primary",
@@ -63,6 +64,7 @@ const btnSave = ref(new ButtonExport({
     button : "save"
   }
 }));
+*/
 
 onMounted(() => {
   if (props.visibility) {

--- a/src/components/carte/control/ElevationPath.vue
+++ b/src/components/carte/control/ElevationPath.vue
@@ -18,15 +18,15 @@ const log = useLogger();
 const map = inject(props.mapId);
 const elevationPath = ref(new ElevationPath(props.elevationPathOptions));
 const button = ref(new ButtonExport({
-  title : "Enregistrer",
+  title : "Exporter",
   kind : "primary",
-  download : false,
+  download : true,
   control: elevationPath.value,
   format : "geojson",
-  menu : false,
+  menu : true,
   icons : {
     menu : "",
-    button : "save"
+    button : "export"
   }
 }));
 

--- a/src/components/carte/control/Isocurve.vue
+++ b/src/components/carte/control/Isocurve.vue
@@ -23,16 +23,16 @@ const store = useDataStore();
 const map = inject(props.mapId)
 const isocurve = ref(new Isocurve(props.isocurveOptions))
 const button = ref(new ButtonExport({
-  title : "Enregistrer",
+  title : "Exporter",
   kind : "primary",
-  download : false,
+  download : true,
   control: isocurve.value,
   format : "geojson",
-  menu : false,
+  menu : true,
   direction : "column",
   icons : {
     menu : "",
-    button : "save"
+    button : "export"
   }
 }));
 

--- a/src/components/carte/control/Route.vue
+++ b/src/components/carte/control/Route.vue
@@ -23,16 +23,16 @@ const store = useDataStore();
 const map = inject(props.mapId);
 const route = ref(new Route(props.routeOptions));
 const button = ref(new ButtonExport({
-  title : "Enregistrer",
+  title : "Exporter",
   kind : "primary",
-  download : false,
+  download : true,
   control: route.value,
   format : "geojson",
-  menu : false,
+  menu : true,
   direction : "column",
   icons : {
     menu : "",
-    button : "save"
+    button : "export"
   }
 }));
 


### PR DESCRIPTION
Désactivation des boutons "Enregistrer" en attente de l'espace perso

## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [ ] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [ ] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [ ] Bugfix
- [x] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :

Les boutons "Enregistrer" étaient présents sur l'entrée carto pour les widgets drawing, route, isocurve, altipath. Non fonctionnels tant qu'on a pas l'espace perso.
![image](https://github.com/user-attachments/assets/5b4ec463-03df-4a17-8dd9-11da3ac3b9cb)


## Quel est le nouveau comportement :
Les boutons enregistrer sont remplacés par les boutons "exporter" permettant d'exporter son croquis ou calcul. Ajout du menu pour choisir titre description et format
![image](https://github.com/user-attachments/assets/a04f4275-606e-40dc-ab3e-45b5e57f01d1)
![image](https://github.com/user-attachments/assets/ac7676ef-57a7-432d-b4b6-de0e7fff1991)

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->
