### PR TITLE
opti perf de chargement catalogue

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -1,15 +1,10 @@
 # Unreleased
 
-<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.5...HEAD>
+<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.6...HEAD>
 
-## 🔖 version 1.0.5 - __DATE__
+## 🔖 version 1.0.6 - __DATE__
 
 ### 🎉 Résumé
-
-Ajout d'une fonctionnalité pour exporter sur son ordinateur au format souhaité ses dessins, itinéraires, isochrones, profils altimétriques.
-La recherche par coordonnées est désormais accessible via la recherche avancée.
-Le widget Catalogue ("Cartalogue") tri désormais les sections et le titre des couches par ordre alphabétique. La description des couches peut être rendue visible en cliquant sur un bouton "Afficher plus".
-Les résultats de calcul d'itinéraire sont affichés de manière plus lisible.
 
 ### 💥 Breaking changes
 
@@ -17,14 +12,7 @@ Les résultats de calcul d'itinéraire sont affichés de manière plus lisible.
 
 #### ✨ [Ajout]
 
-  - Croquis et calculs : Ajout d'un bouton pour exporter ses créations de type croquis ou calcul (#509)
-
 #### 🔨 [Evolution]
-
-  - Partage : Mise en conformité avec la maquette du bouton copier-coller (#479)
-  - Cartalogue : tri par ordre alphabétique des couches selon le thème et le producteur (#503)
-  - Cartalogue : description des couches cachée, ajout d'un bouton "Afficher plus" pour la voir (#507)
-  - Recherche : la recherche par coordonnées est intégrée à la recherche avancée (#508)
 
 #### 🔥 [Obsolète]
 
@@ -32,8 +20,7 @@ Les résultats de calcul d'itinéraire sont affichés de manière plus lisible.
 
 #### 🐛 [Correction]
 
-  - Itinéraire : correction de l'affichage des résultats d'itinéraire (#508)
-  - Catalogue : correction en cas de couche sans configuration chargée (#503)
+  - Cartalogue : correction de l'algorithme utilisé pour sa création qui ralentissait fortement le chargement de la page (#516)
 
 #### 🔒 [Sécurité]
 

--- a/src/components/menu/catalogue/DataLayerCatalogue.vue
+++ b/src/components/menu/catalogue/DataLayerCatalogue.vue
@@ -51,6 +51,7 @@ const activeAccordion2 = ref(-1)
           :layers-count="producer[1].length"
           :key="producer[0] + '-menuCatalogueThematique'">
           <LayerList
+            v-if="idx == activeAccordion1"
             :key="producer[0]"
             :list-name="producer[0]"
             :selected-layers="selectedLayers"
@@ -71,6 +72,7 @@ const activeAccordion2 = ref(-1)
             :layers-count="thematic[1].length"
             :key="thematic[0] + '-menuCatalogueThematique'">
             <LayerList
+              v-if="idx == activeAccordion2"
               :key="thematic[0]"
               :list-name="thematic[0]"
               :selected-layers="selectedLayers"

--- a/src/components/menu/catalogue/DataLayerCatalogue.vue
+++ b/src/components/menu/catalogue/DataLayerCatalogue.vue
@@ -23,13 +23,13 @@ const props = defineProps({
 const dataStore = useDataStore();
 
 const thematics = computed(() => {
-  return dataStore.getThematics().value.map(thematic => {
+  return dataStore.getThematics().map(thematic => {
     return [thematic[0],   props.dataLayers.filter(layer => thematic[1].includes(layer.key))]
   })
 })
 
 const producers = computed(() => {
-  return dataStore.getProducers().value.map(producer => {
+  return dataStore.getProducers().map(producer => {
     return [producer[0],   props.dataLayers.filter(layer => producer[1].includes(layer.key))]
   })
 });

--- a/src/components/menu/catalogue/DataLayerCatalogue.vue
+++ b/src/components/menu/catalogue/DataLayerCatalogue.vue
@@ -44,8 +44,8 @@ const activeAccordion2 = ref(-1)
       <DsfrAccordionsGroup
         v-model="activeAccordion1">
         <template v-for="(producer, idx) in producers" :key="producer[0]">
-          <div>
-            <MenuCatalogueThematique v-show="currDataFilter === 'producteur'"  v-if="producer[1].length > 0"
+          <div v-show="currDataFilter === 'producteur'" >
+            <MenuCatalogueThematique  v-show="producer[1].length > 0"
           :id="idx"
           :thematic-label="producer[0]"
           :layers-count="producer[1].length"
@@ -65,8 +65,8 @@ const activeAccordion2 = ref(-1)
       <DsfrAccordionsGroup 
       v-model="activeAccordion2">
         <template v-for="(thematic, idx) in thematics" :key="thematic[0]">
-          <div>
-            <MenuCatalogueThematique v-show="currDataFilter === 'theme'" v-if="thematic[1].length > 0"
+          <div v-show="currDataFilter === 'theme'" >
+            <MenuCatalogueThematique v-show="thematic[1].length > 0"
             :id="idx"
             :thematic-label="thematic[0]"
             :layers-count="thematic[1].length"

--- a/src/components/menu/catalogue/DataLayerCatalogue.vue
+++ b/src/components/menu/catalogue/DataLayerCatalogue.vue
@@ -24,17 +24,13 @@ const dataStore = useDataStore();
 
 const thematics = computed(() => {
   return dataStore.getThematics().value.map(thematic => {
-    const layerArr = thematic[1].filter(layer => props.dataLayers.map(layer => layer.key).includes(layer.key))
-    const ret = [thematic[0], layerArr]
-    return ret;
+    return [thematic[0],   props.dataLayers.filter(layer => thematic[1].includes(layer.key))]
   })
 })
 
 const producers = computed(() => {
-  return dataStore.getProducers().value.map(thematic => {
-    const layerArr = thematic[1].filter(layer => props.dataLayers.map(layer => layer.key).includes(layer.key))
-    const ret = [thematic[0], layerArr]
-    return ret;
+  return dataStore.getProducers().value.map(producer => {
+    return [producer[0],   props.dataLayers.filter(layer => producer[1].includes(layer.key))]
   })
 });
 

--- a/src/components/menu/catalogue/MenuCatalogue.vue
+++ b/src/components/menu/catalogue/MenuCatalogue.vue
@@ -66,7 +66,7 @@ const baseLayers = computed(() => {
     if (layer.hasOwnProperty("base") &&  layer.base) {
       return layer
     }
-  })
+  }).sort((a, b) => a.title.localeCompare(b.title, 'fr', { sensitivity: 'base' }))
 });
 
 /** Liste des couches de données */
@@ -75,7 +75,7 @@ const dataLayers = computed(() => {
     if (!layer.hasOwnProperty("base") || !layer.base) {
       return layer;
     }
-  })
+  }).sort((a, b) => a.title.localeCompare(b.title, 'fr', { sensitivity: 'base' }))
 });
 
 /** Titre principal */

--- a/src/stores/dataStore.js
+++ b/src/stores/dataStore.js
@@ -38,8 +38,9 @@ export const useDataStore = defineStore('data', () => {
       return [thematic, getLayersByThematic(thematic)]
     })
     return ret
-});
-const m_producers = computed(() => {
+  });
+
+  const m_producers = computed(() => {
     let ret = []
     // Initialisation Objet producers
     // réduction à des valeurs uniques
@@ -51,7 +52,7 @@ const m_producers = computed(() => {
     return ret.map((producer) => {
       return [producer, getLayersByProducer(producer)]
     })
-});
+  });
 
   /**
    * @todo utiliser l'implementation officielle @link{https://vueuse.org/core/useFetch/}
@@ -99,7 +100,8 @@ const m_producers = computed(() => {
           }
           // sinon on supprime l'entrée edito avec le filter
           return undefined;
-      }).filter(entry => entry));
+        }).filter(entry => entry)
+      );
 
       // on fusionne tech et priv avec l'objet edito nettoyé
       const res = {
@@ -109,11 +111,11 @@ const m_producers = computed(() => {
       };
 
       // on ajoute la clé (ID) aux propriétés
-      Object.keys(res).map((key) => { 
+      Object.keys(res).map((key) => {
         // On filtre les couches : 
         // - on garde celle qui correspondent à un des filterServices
         // - on supprime celles qui possèdent une des filterProjections
-        if(filterServices.split(",").some(service => res[key].serviceParams.id.includes(service)) && 
+        if (filterServices.split(",").some(service => res[key].serviceParams.id.includes(service)) &&
           !filterProjections.split(",").some(proj => res[key].defaultProjection.includes(proj))) {
           res[key].key = key; // ID
           let ret = {};
@@ -127,14 +129,14 @@ const m_producers = computed(() => {
             themes.value.push(...ret[key].thematic)
           }
           // initialise les sans thématiques à Autres
-          if (!ret[key].hasOwnProperty("thematic") || ret[key].thematic.length === 0) { 
+          if (!ret[key].hasOwnProperty("thematic") || ret[key].thematic.length === 0) {
             ret[key].thematic = ["Autres"];
           }
           if (!ret[key].hasOwnProperty("producer") || ret[key].producer.length === 0) {
             ret[key].producer = ["Autres"];
           }
           return ret;
-        } else  {
+        } else {
           delete res[key];
         }
       });
@@ -158,14 +160,13 @@ const m_producers = computed(() => {
       this.isLoaded = false;
       error.value = err.message;
     }
-
   }
 
-  function getTerritories () {
+  function getTerritories() {
     return m_territories.value;
   }
 
-  function getContacts () {
+  function getContacts() {
     return m_contacts.value;
   }
 
@@ -203,8 +204,7 @@ const m_producers = computed(() => {
   function getLayersSignatures() {
     return Object.fromEntries(
       Object.entries(m_layers.value)
-        .map(([key, val]) => [val.name, val.serviceParams.id.split(":")[1]]
-      )
+        .map(([key, val]) => [val.name, val.serviceParams.id.split(":")[1]])
     );
   }
 
@@ -331,13 +331,13 @@ const m_producers = computed(() => {
     var params = null;
 
     if (id) {
-        // get layer configuration object
-        var l = this.getLayerByID(id);
-        params = {};
-        params.projection = l.defaultProjection;
-        params.minScale = l.globalConstraint.minScaleDenominator;
-        params.maxScale = l.globalConstraint.maxScaleDenominator;
-        params.extent = l.globalConstraint.bbox;
+      // get layer configuration object
+      var l = this.getLayerByID(id);
+      params = {};
+      params.projection = l.defaultProjection;
+      params.minScale = l.globalConstraint.minScaleDenominator;
+      params.maxScale = l.globalConstraint.maxScaleDenominator;
+      params.extent = l.globalConstraint.bbox;
     }
 
     return params;

--- a/src/stores/dataStore.js
+++ b/src/stores/dataStore.js
@@ -171,11 +171,8 @@ export const useDataStore = defineStore('data', () => {
   function getLayersByThematic(layers, thematic) {
     return Object.keys(layers).filter(key => layers[key].thematic.includes(thematic))
     .map(layerID => {
-        let layerObj = {}
-        layerObj[layerID] = layers[layerID]
-        return layers[layerID]
+        return layerID
     })
-    .sort((a, b) => a.title.localeCompare(b.title, 'fr', { sensitivity: 'base' }))
   }
 
   function getProducers() {
@@ -185,11 +182,8 @@ export const useDataStore = defineStore('data', () => {
   function getLayersByProducer(layers, producer) {
     return Object.keys(layers).filter(key => layers[key].producer.includes(producer))
     .map(layerID => {
-        let layerObj = {}
-        layerObj[layerID] = layers[layerID]
-        return layers[layerID]
+        return layerID
     })
-    .sort((a, b) => a.title.localeCompare(b.title, 'fr', { sensitivity: 'base' }))
   }
 
   function getFeatured() {

--- a/src/stores/dataStore.js
+++ b/src/stores/dataStore.js
@@ -10,8 +10,7 @@ import {
  */
 export const useDataStore = defineStore('data', () => {
   const m_informations = ref({});
-  const m_thematics = ref([]);
-  const m_producers = ref([]);
+
   const m_layers = ref({});
   const m_generalOptions = ref({});
   const m_tileMatrixSets = ref({});
@@ -22,6 +21,37 @@ export const useDataStore = defineStore('data', () => {
   const error = ref("");
   const filterServices = "WMTS,WMS,TMS";
   const filterProjections = "IGNF:LAMB93,EPSG:2154";
+
+  const themes = ref([])
+  const producers = ref([])
+
+  const m_thematics = computed(() => {
+    let ret = []
+    // Initialisation Objet thematiques 
+    // réduction à des valeurs uniques
+    ret = [...new Set(themes.value)].sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
+    // Ajout catégorie Autres en fin de tableau
+    ret.push("Autres");
+    // Les layers sont des copies de m_layers
+    // Structure : [["thematic1", [{layer1}, {layer2}, ...]], ...]
+    ret = ret.map((thematic) => {
+      return [thematic, getLayersByThematic(thematic)]
+    })
+    return ret
+});
+const m_producers = computed(() => {
+    let ret = []
+    // Initialisation Objet producers
+    // réduction à des valeurs uniques
+    ret = [...new Set(producers.value)].sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
+    // Ajout catégorie Autres en fin de tableau
+    ret.push("Autres");
+    // Les layers sont des copies de m_layers
+    // Structure : [["thematic1", [{layer1}, {layer2}, ...]], ...]
+    return ret.map((producer) => {
+      return [producer, getLayersByProducer(producer)]
+    })
+});
 
   /**
    * @todo utiliser l'implementation officielle @link{https://vueuse.org/core/useFetch/}
@@ -43,8 +73,6 @@ export const useDataStore = defineStore('data', () => {
       const edito = await editoRes.json();
       const priv = await privateRes.json();
 
-      var themes = []
-      var producers = []
       const editoWithTech = Object.fromEntries(
         Object.keys(edito.layers).map(id => {
           // si l'id de la couche dans edito a bien une correspondance dans tech ou private
@@ -54,23 +82,14 @@ export const useDataStore = defineStore('data', () => {
             if(edito.layers[id].hasOwnProperty("thematic") 
               && edito.layers[id].thematic.length > 0) {
                 if (typeof edito.layers[id].thematic == 'string') {
-                  // this line convert the thematic in array donc passe aussi dans la condition suivante
                   ret.thematic = [edito.layers[id].thematic];
                 }
-                if (Array.isArray(edito.layers[id].thematic)) {
-                  themes.push(...edito.layers[id].thematic)
-                }
-
             }
             // gestion des producers si c'est une string on tranforme en tableau
             if(edito.layers[id].hasOwnProperty("producer")
               && edito.layers[id].producer.length > 0) {
                 if (typeof edito.layers[id].producer == 'string') {
-                  // this line convert the thematic in array donc passe aussi dans la condition suivante
                   ret.producer = [edito.layers[id].producer];
-                }
-                if (Array.isArray(edito.layers[id].producer)) {
-                  producers.push(...edito.layers[id].producer)
                 }
             }
             // on rajoute les info edito à l'entrée
@@ -103,6 +122,14 @@ export const useDataStore = defineStore('data', () => {
           res[key].key = key;
           let ret = {};
           ret[key] = res[key];
+          // Ajout des producteurs à la liste
+          if (Array.isArray(ret[key].producer)) {
+            producers.value.push(...ret[key].producer)
+          }
+          // Ajout des thématiques à la liste
+          if (Array.isArray(ret[key].thematic)) {
+            themes.value.push(...ret[key].thematic)
+          }
           // initialise les sans thématiques à Autres
           if (!ret[key].hasOwnProperty("thematic") || ret[key].thematic.length == 0) { ret[key].thematic =  ["Autres"];}
           if (!ret[key].hasOwnProperty("producer") || ret[key].producer.length == 0) { ret[key].producer =  ["Autres"];}
@@ -122,25 +149,6 @@ export const useDataStore = defineStore('data', () => {
         ...priv.generalOptions.apiKeys
       }
       m_tileMatrixSets.value = tech.tileMatrixSets;
-
-      // Initialisation Objet thematiques 
-      // réduction à des valeurs uniques
-      m_thematics.value = [...new Set(themes)].sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
-      m_thematics.value.push("Autres");
-      // Les layers sont des copies de m_layers
-      // Structure : [["thematic1", [{layer1}, {layer2}, ...]], ...]
-      m_thematics.value = m_thematics.value.map((thematic) => {
-        return [thematic, getLayersByThematic(m_layers.value, thematic)]
-      })
-      // Initialisation Objet producers
-      // réduction à des valeurs uniques
-      m_producers.value = [...new Set(producers)].sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
-      m_producers.value.push("Autres");
-      // Les layers sont des copies de m_layers
-      // Structure : [["thematic1", [{layer1}, {layer2}, ...]], ...]
-      m_producers.value = m_producers.value.map((producer) => {
-        return [producer, getLayersByProducer(m_layers.value, producer)]
-      })
 
       this.isLoaded = true;
       return res;
@@ -168,8 +176,8 @@ export const useDataStore = defineStore('data', () => {
   function getThematics() {
     return m_thematics;
   }
-  function getLayersByThematic(layers, thematic) {
-    return Object.keys(layers).filter(key => layers[key].thematic.includes(thematic))
+  function getLayersByThematic(thematic) {
+    return Object.keys(m_layers.value).filter(key => m_layers.value[key].thematic.includes(thematic))
     .map(layerID => {
         return layerID
     })
@@ -179,8 +187,8 @@ export const useDataStore = defineStore('data', () => {
     return m_producers;
   }
 
-  function getLayersByProducer(layers, producer) {
-    return Object.keys(layers).filter(key => layers[key].producer.includes(producer))
+  function getLayersByProducer(producer) {
+    return Object.keys(m_layers.value).filter(key => m_layers.value[key].producer.includes(producer))
     .map(layerID => {
         return layerID
     })
@@ -351,11 +359,15 @@ export const useDataStore = defineStore('data', () => {
     isLoaded,
     filterProjections,
     filterServices,
+    producers,
+    themes,
     fetchData,
     getTerritories,
     getContacts,
     getInformations,
+    getLayersByThematic,
     getThematics,
+    getLayersByProducer,
     getProducers,
     getFeatured,
     getLayers,


### PR DESCRIPTION
Le rendu des listes du catalogue sans condition v-if posait problème.

Cette nouvelle condition de rendu permet de ne générer la liste que si l'accordeon de la thématique ou du producteur est déroulée.


Par ailleurs il a fallu modifier le code d'enregistrement des thematiques et producteurs car en l'état on ajoutait parfois des catégories à ces listes alors qu'elles finissaient par s'avérer vide (exemple SCHAPI que des couches en WFS).
Or cela avait un impact sur le rendu du catalogue.


=> Vérifier que le chargement est court 
=> Vérifier que les catégories Autres sont bien remplies
=> Vérifier que la barre de recherche fonctionne toujours correctement.

