### PR TITLE
Eviter le chargement de toutes les projections

### DIFF
--- a/src/components/carte/Map.vue
+++ b/src/components/carte/Map.vue
@@ -49,7 +49,7 @@ provide(props.mapId, map)
 onMounted(() => {
   // On déclenche l'ecriture dans le dom
   
-  CRS.load();
+  CRS.loadByDefault();
   map.setTarget(mapRef.value)
   
   // On ajoute une option d'accessibilité


### PR DESCRIPTION
cf. https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/525#issuecomment-2806979906

On évite de charger toutes les projections !
On charge uniquement celles par défaut : 
```js
   /**
    * Load definition projection by default
    *
    * include into proj4 :
    * - WGS84
    * - ['EPSG:4326']
    * - ['EPSG:3785'], ['EPSG:3857'], GOOGLE, ['EPSG:900913'], ['EPSG:102113']
    * +
    * - ["EPSG:2154"], ["EPSG:27571"],  ["EPSG:27572"],  ["EPSG:27573"],  ["EPSG:2757"],
    * - ["CRS:84"],
    * - ["IGNF:LAMB93"],
    * - ["IGNF:LAMBE"], ["IGNF:LAMB1"],  ["IGNF:LAMB2"],  ["IGNF:LAMB3"],  ["IGNF:LAMB4"],
    * - ["IGNF:RGF93G"],
    * - ["IGNF:WGS84G"]
    */
```
