### PR TITLE
🚑 fenêtre de croquis cachée par le panel entrée carto

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -33,6 +33,7 @@
   - Itinéraire / Isochrone : Les boutons d'enregistrement et d'export n'aparaissent que sur la fenêtre de résultats du calcul (24ba88876e8dda0dcf536721ccab99d0ee260a0d)
   - Menus cartographiques : Les menus de gestion des widgets, cartalogue, et de fonctions liées à la carte ne se superposent plus avec ceux des autres outils (#535)
   - Performance : amélioration du temps de chargement de l'entrée cartographique (#529, #532)
+  - Croquis : fenêtre commentaire cachée (#560)
 
 #### 🔒 [Sécurité]
 

--- a/src/components/CartoAndTools.vue
+++ b/src/components/CartoAndTools.vue
@@ -215,4 +215,7 @@ Cache le menu latéral si widget ouvert...
 #map-and-tools-container:has(.gp-label-div) .menu-toggle-wrap.left .menu-content-list  {
     display: none;
 }
+#map-and-tools-container:has(.gp-styling-div) .menu-toggle-wrap.left .menu-content-list  {
+    display: none;
+}
 </style>

--- a/src/components/CartoAndTools.vue
+++ b/src/components/CartoAndTools.vue
@@ -211,4 +211,8 @@ Cache le menu latéral si widget ouvert...
 #map-and-tools-container:has(#position-container-bottom-left > div > button[aria-pressed="true"]) .menu-toggle-wrap.left .menu-content-list  {
   display: none;
 }
+
+#map-and-tools-container:has(.gp-label-div) .menu-toggle-wrap.left .menu-content-list  {
+    display: none;
+}
 </style>

--- a/src/components/menu/MenuLateralWrapper.vue
+++ b/src/components/menu/MenuLateralWrapper.vue
@@ -15,6 +15,7 @@
 
 <script setup lang="js">
 import { VIcon } from '@gouvminint/vue-dsfr'
+import { useDocumentVisibility } from '@vueuse/core';
 
 const props = defineProps({
   side: String,
@@ -51,6 +52,15 @@ function closeMenu() {
   is_expanded.value = false
 }
 function openMenu() {
+  // cas particulier des fenêtres d'annotation
+    const closeButton1 = document.querySelector('.gp-label-div button.GPpanelClose');
+    if (closeButton1) {
+      closeButton1.click();
+    }
+    const closeButton2 = document.querySelector('.gp-styling-div button.GPpanelClose');
+    if (closeButton2) {
+      closeButton2.click();
+    }
   is_expanded.value = true
 }
 


### PR DESCRIPTION
Correction de ce comportement : https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/560

Même solution que dans cette PR : https://github.com/IGNF/cartes.gouv.fr-entree-carto/pull/535

Solution :
On cache le menu tant qu'une fenêtre d'annotation est ouverte
