### PR TITLE
fix(ui:share): boutton copy-paste retiré car inutile (fix #589)

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -29,6 +29,9 @@ Diverses corrections sur l'espace personnel (favoris), amélioration du gestionn
 
 #### 🔥 [Suppression]
 
+    - Carte : suppression de la patience affichée sur la carte (#590)
+    - Partage : suppression du petit de bouton de partage situé après ceux des réseaux sociaux (#591)
+
 #### 🐛 [Correction]
 
     - Lien de partage : Gestion correcte de l'ordre des couches dans le permalien (#559)

--- a/src/components/carte/control/ShareModal.vue
+++ b/src/components/carte/control/ShareModal.vue
@@ -115,7 +115,6 @@ defineExpose({
     <div>
       <p>
         <DsfrShare
-          copy-label="Copier dans le presse-papier"
           :mail="shareMail"
           :networks="shareNetworks"
           title="Partages"
@@ -168,6 +167,11 @@ defineExpose({
   .fr-btn--instagram::before {
     -webkit-mask-image: url("../../../../node_modules/@gouvfr/dsfr/dist/icons/logo/instagram-line.svg");
     mask-image: url("../../../../node_modules/@gouvfr/dsfr/dist/icons/logo/instagram-line.svg");
+  }
+
+  /* le composant share de vue dsfr ne permet pas de retirer le bouton de partage par défaut. On le cache en css */
+  ul.fr-btns-group button.fr-btn--copy {
+    display: none;
   }
 </style>
 


### PR DESCRIPTION
Retrait du bouton copier coller inutile du composant share
## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :
Bouton de partage inutie et non fonctionnel (celui après les RS) : 
![image](https://github.com/user-attachments/assets/7a661144-ff45-4b22-9a0e-8abba8fd85d5)


Numéro du ticket : fix #589


## Quel est le nouveau comportement :
![image](https://github.com/user-attachments/assets/3f7d54b0-3f56-451e-b43a-5b215107e9c0)

<!-- Décrire le comportement ou les changements ajoutés par cette PR -->
Bouton caché en CSS (car le composant VueDSFR semble en imposer un)

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non
