### PR TITLE
Ajout d'une fenêtre consentement standard et personnalisé

### DIFF
--- a/public/data/alerts.json
+++ b/public/data/alerts.json
@@ -13,7 +13,7 @@
     "visibility": {
       "homepage": false,
       "contact": false,
-      "map": true,
+      "map": false,
       "serviceLevel": true
     }
   },
@@ -49,7 +49,7 @@
     "visibility": {
       "homepage": true,
       "contact": false,
-      "map": true,
+      "map": false,
       "serviceLevel": false
     }
   }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -66,6 +66,7 @@ declare module 'vue' {
     MenuLateralWrapper: typeof import('./components/menu/MenuLateralWrapper.vue')['default']
     MenuTierce: typeof import('./components/menu/MenuTierce.vue')['default']
     ModalConsent: typeof import('./components/modals/ModalConsent.vue')['default']
+    ModalConsentCustom: typeof import('./components/modals/ModalConsentCustom.vue')['default']
     ModalInformation: typeof import('./components/modals/ModalInformation.vue')['default']
     ModalLogin: typeof import('./components/modals/ModalLogin.vue')['default']
     ModalReportingStart: typeof import('./components/modals/ModalReportingStart.vue')['default']

--- a/src/components/modals/ModalConsent.vue
+++ b/src/components/modals/ModalConsent.vue
@@ -71,29 +71,28 @@ const onCustomizeCookies = () => {
 </script>
 
 <template>
-  <!-- Modale : Gestion des cookies (+ Eulerian) -->
-  <DsfrModal 
-    :opened="consentModalOpened" 
-    :title="title"
-    :size="size" 
-    @close="onModalConsentClose"
-  >
-    <!-- slot : c'est ici que l'on customise le contenu ! -->
+  <div v-if="consentModalOpened" class="fr-consent-banner">
+    <h2 class="fr-h6">{{ title }}</h2>
     <p id="my-consent">
-      <DsfrConsent
-        @accept-all="onAcceptConsentAll()"
-        @refuse-all="onRefuseConsentAll()"
-        @customize="onCustomizeCookies()"
-      >
-        Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et 
-        les services disponibles sur ce site. 
-        Pour en savoir plus, visitez la page <a :href="url">Données personnelles et cookies</a>.  
-        Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.
-        Préférences pour tous les services.
-      </DsfrConsent>
+        <DsfrConsent
+          @accept-all="onAcceptConsentAll()"
+          @refuse-all="onRefuseConsentAll()"
+          @customize="onCustomizeCookies()"
+        >
+          Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et 
+          les services disponibles sur ce site. 
+          Pour en savoir plus, visitez la page <a :href="url">Données personnelles et cookies</a>.  
+          Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.
+          Préférences pour tous les services.
+        </DsfrConsent>
     </p>
-  </DsfrModal>
-   <!-- Modale : Gestion des cookies personnalisés -->
+    <DsfrButton
+      id="fr-consent-modal-hidden-control-button"
+      class="fr-hidden"
+      @click="onModalConsentClose"
+    />
+  </div>
+  <!-- Modale : Gestion des cookies personnalisés -->
   <ModalConsentCustom ref="refModalConsentCustom" />
 </template>
 
@@ -102,6 +101,6 @@ const onCustomizeCookies = () => {
   > on centre les boutons 
 */
 .fr-btns-group--inline-sm.fr-btns-group--right.fr-btns-group--inline-reverse {
-  justify-content: center;
+  justify-content: end;
 }
 </style>

--- a/src/components/modals/ModalConsentCustom.vue
+++ b/src/components/modals/ModalConsentCustom.vue
@@ -15,32 +15,25 @@ export default {};
 import { useRouter } from 'vue-router';
 import { useBaseUrl } from '@/composables/baseUrl';
 
-import ModalConsentCustom from './ModalConsentCustom.vue';
-
 // plugin local
 import { useEulerian } from '@/plugins/Eulerian.js';
 
 const router = useRouter();
 const eulerian = useEulerian();
 
-const refModalConsentCustom = ref(null);
+const consentCustomModalOpened = ref(false);
 
-// gestion de la modale de consentement 'eulerian'
-var open = eulerian.hasKey();
-
-const consentModalOpened = ref(!open);
-
-const title = "À propos des cookies sur cartes.gouv.fr";
+const title = "Panneau de gestion des cookies";
 const size = "md";
 const url = useBaseUrl() + "/donnees-personnelles";
 
-const openModalConsent = () => {
-  consentModalOpened.value = true;
+const openModalConsentCustom = () => {
+  consentCustomModalOpened.value = true;
   eulerian.pause();
 }
 
-const onModalConsentClose = () => {
-  consentModalOpened.value = false;
+const onModalConsentCustomClose = () => {
+  consentCustomModalOpened.value = false;
   router.push({ path : '/' });
   // INFO
   // l'utilisateur a t il fait un choix ou fermeture direct ?
@@ -48,56 +41,57 @@ const onModalConsentClose = () => {
 }
 
 defineExpose({
-  openModalConsent,
-  onModalConsentClose
+  openModalConsentCustom,
+  onModalConsentCustomClose
 });
 
 const onAcceptConsentAll = () => {
   eulerian.start();
-  onModalConsentClose();
+  onModalConsentCustomClose();
 }
 const onRefuseConsentAll = () => {
   eulerian.stop();
-  onModalConsentClose();
+  onModalConsentCustomClose();
 }
-const onCustomizeCookies = () => {
-  eulerian.stop();
-  onModalConsentClose();
-  if (refModalConsentCustom.value) {
-    refModalConsentCustom.value.openModalConsentCustom();
-  }
-}
-
 </script>
 
 <template>
   <!-- Modale : Gestion des cookies (+ Eulerian) -->
   <DsfrModal 
-    :opened="consentModalOpened" 
+    :opened="consentCustomModalOpened" 
     :title="title"
     :size="size" 
-    @close="onModalConsentClose"
+    @close="onModalConsentCustomClose"
   >
     <!-- slot : c'est ici que l'on customise le contenu ! -->
-    <p id="my-consent">
+    <p id="my-consent-custom">
       <DsfrConsent
         @accept-all="onAcceptConsentAll()"
         @refuse-all="onRefuseConsentAll()"
-        @customize="onCustomizeCookies()"
       >
-        Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et 
-        les services disponibles sur ce site. 
-        Pour en savoir plus, visitez la page <a :href="url">Données personnelles et cookies</a>.  
-        Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.
         Préférences pour tous les services.
+        <a :href="url">Données personnelles et cookies</a>
       </DsfrConsent>
     </p>
+    <hr>
+    <div>
+      <h5>Eulerian Analytics</h5>
+      En cliquant sur 'Tout accepter', vous consentez à l'utilisation des cookies pour nous aider
+      à améliorer notre site web en collectant et en rapportant des informations sur votre
+      utilisation grâce à Eulerian Analytics. <br>
+      Si vous n'êtes pas d'accord, veuillez cliquer sur 'Tout refuser'. 
+      Votre expérience de navigation ne sera pas affectée.
+    </div>
   </DsfrModal>
-   <!-- Modale : Gestion des cookies personnalisés -->
-  <ModalConsentCustom ref="refModalConsentCustom" />
 </template>
 
 <style>
+/* Surcharge sur le composant DsfrConsent : 
+  > on n'affiche pas le bouton 'Personnaliser' 
+*/
+#my-consent-custom button[title="Personnaliser les cookies"] {
+  display: none;
+}
 /* Surcharge sur le composant DsfrConsent : 
   > on centre les boutons 
 */

--- a/src/components/modals/ModalConsentCustom.vue
+++ b/src/components/modals/ModalConsentCustom.vue
@@ -53,6 +53,10 @@ const onRefuseConsentAll = () => {
   eulerian.stop();
   onModalConsentCustomClose();
 }
+const onClickValideChoice = () => {
+  onModalConsentCustomClose();
+}
+
 </script>
 
 <template>
@@ -82,6 +86,13 @@ const onRefuseConsentAll = () => {
       Si vous n'êtes pas d'accord, veuillez cliquer sur 'Tout refuser'. 
       Votre expérience de navigation ne sera pas affectée.
     </div>
+    <div class="fr-consent-manager__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-sm">
+      <DsfrButton
+        @click="onClickValideChoice"
+      >
+        Confirmer mes choix
+      </DsfrButton>
+    </div>
   </DsfrModal>
 </template>
 
@@ -96,6 +107,6 @@ const onRefuseConsentAll = () => {
   > on centre les boutons 
 */
 .fr-btns-group--inline-sm.fr-btns-group--right.fr-btns-group--inline-reverse {
-  justify-content: center;
+  justify-content: end;
 }
 </style>

--- a/src/components/modals/ModalConsentCustom.vue
+++ b/src/components/modals/ModalConsentCustom.vue
@@ -22,6 +22,7 @@ const router = useRouter();
 const eulerian = useEulerian();
 
 const consentCustomModalOpened = ref(false);
+const refConsent = ref(null);
 
 const title = "Panneau de gestion des cookies";
 const size = "md";
@@ -57,18 +58,39 @@ const onClickValideChoice = () => {
   onModalConsentCustomClose();
 }
 
+onMounted(() => {
+  if (refConsent.value) {}
+})
+
+onBeforeUpdate(() => {
+  if (refConsent.value) {
+    var btn = refConsent.value.querySelector('button[title="Refuser tous les cookies"]');
+    btn.classList.add("fr-btn--secondary");
+  }
+})
+
+onUpdated(() => {
+  if (refConsent.value) {
+    // HACK
+    var btn = refConsent.value.querySelector('button[title="Refuser tous les cookies"]');
+    btn.classList.add("fr-btn--secondary");
+    var ul = refConsent.value.querySelector('ul');
+    ul.classList.replace("fr-btns-group--inline-reverse", "fr-btns-group--inline");
+  }
+})
+
 </script>
 
 <template>
   <!-- Modale : Gestion des cookies (+ Eulerian) -->
-  <DsfrModal 
+  <DsfrModal
     :opened="consentCustomModalOpened" 
     :title="title"
     :size="size" 
     @close="onModalConsentCustomClose"
   >
     <!-- slot : c'est ici que l'on customise le contenu ! -->
-    <p id="my-consent-custom">
+    <p id="my-consent-custom" ref="refConsent">
       <DsfrConsent
         @accept-all="onAcceptConsentAll()"
         @refuse-all="onRefuseConsentAll()"
@@ -98,7 +120,7 @@ const onClickValideChoice = () => {
 
 <style>
 /* Surcharge sur le composant DsfrConsent : 
-  > on n'affiche pas le bouton 'Personnaliser' 
+  > on n'affiche pas le bouton 'Personnaliser les cookies' 
 */
 #my-consent-custom button[title="Personnaliser les cookies"] {
   display: none;

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -19,6 +19,7 @@ import { useBaseUrl } from '@/composables/baseUrl'
 import { Notivue, Notification, push, lightTheme, darkTheme, type NotivueTheme} from 'notivue'
 // components
 import ModalConsent from '@/components/modals/ModalConsent.vue'
+import ModalConsentCustom from '@/components/modals/ModalConsentCustom.vue'
 import ModalTheme from '@/components/modals/ModalTheme.vue'
 // stores
 import { useAppStore } from "@/stores/appStore"
@@ -60,6 +61,7 @@ const afterMandatoryLinks = computed(() => {
 
 // ref sur le component ModalConsent
 const refModalConsent = ref<InstanceType<typeof ModalConsent> | null>(null)
+const refModalConsentCustom = ref<InstanceType<typeof ModalConsentCustom> | null>(null)
 
 // INFO
 // on met à jour les mandatoryLinks pour y ajouter des
@@ -68,7 +70,7 @@ const mandatoryLinks = computed(() => {
   return footerParams.mandatoryLinks.map((element: any) => {
     if (element.label === 'Gestion des cookies') {
       delete element.href
-      element.onclick = refModalConsent.value ? refModalConsent.value.openModalConsent : null
+      element.onclick = refModalConsentCustom.value ? refModalConsentCustom.value.openModalConsentCustom : null
       element.to = '/'
     }
     return element
@@ -322,6 +324,7 @@ const scrollDown = () => {
 
     <!-- Modale : Gestion des cookies (+ Eulerian) -->
     <ModalConsent ref="refModalConsent" />
+    <ModalConsentCustom ref="refModalConsentCustom" />
   </div>
 </template>
 


### PR DESCRIPTION
Si pas de clef de storage, on affiche la boite de dialogue de consentement standard :
![image](https://github.com/user-attachments/assets/f22e649f-6922-4ab9-ba84-7e907ff49dfb)

On peut personnaliser les cookies (même si on n'en a pas !?) du site en cliquant sur : 
* le bouton "personnaliser" de la boite de consentement standard
* le lien "gestion des cookies"

![image](https://github.com/user-attachments/assets/4aa7f6fa-c412-480d-b2e3-743d837d685a)

Pour recetter, 
> supprimer la clef du localStorage pour faire apparaître la modale de consentement standard.
