### PR TITLE
Synchronisation de l'authentification avec cartes.gouv.fr

### DIFF
--- a/.docker-dev/carto/Dockerfile
+++ b/.docker-dev/carto/Dockerfile
@@ -10,4 +10,4 @@ RUN npm install
 ENV BASE_URL="/cartes" 
 ENV SOURCE_MAP=true
 
-CMD [ "npm", "run", "dev", "--", "--mode", "docker-local" ]
+CMD [ "npm", "run", "dev-local"]

--- a/env/.env.docker-local
+++ b/env/.env.docker-local
@@ -3,7 +3,7 @@ VITE_GPF_CONTEXT="docker-dev-local"
 VITE_GPF_CONF_ALERTS="data/alerts.json"
 VITE_GPF_CONF_ENTREE_CARTO="data/entreeCarto.json"
 
-VITE_GPF_BASE_URL_EXTERNAL="https://cartes.gouv.fr"
+VITE_GPF_BASE_URL_EXTERNAL="http://localhost:1235"
 VITE_GPF_BASE_URL_DOCUMENT="https://data.geopf.fr/documents/"
 
 VITE_GPF_SERVICE_ANOMALY="https://www.geoportail.gouv.fr/wp-json/wp/v2"
@@ -23,10 +23,10 @@ IAM_URL="https://sso.geopf.fr"
 IAM_REALM="geoplateforme"
 IAM_CLIENT_ID="cartes-gouv-fr-carto"
 IAM_CLIENT_SECRET="GLGe8lcjSj7OytvAeHXABrZRFjbu31ny"
-IAM_ENTREPOT_API_URL="https://data.geopf.fr/api"
+IAM_ENTREPOT_API_URL="http://localhost:1235/api"
 # Mode auth remote (proxifié en distant)
-IAM_REDIRECT_REMOTE="https://cartes.gouv.fr"
-IAM_ENTREPOT_API_URL_REMOTE="https://cartes.gouv.fr/api"
+IAM_REDIRECT_REMOTE="http://localhost:1235"
+IAM_ENTREPOT_API_URL_REMOTE="http://localhost:1235/api"
 
 # variable non lu nativement par vitejs
 # uniquement pour information par nodejs lors du build

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "clean:dist": "rimraf dist",
     "build-only": "vite build",
     "dev": "vite --force --host --mode development-local",
+    "dev-local": "vite --force --host --mode docker-local",
     "build": "run-p type-check \"build-only {@}\" --",
     "format": "eslint ./src --fix",
     "lint": "eslint ./src",

--- a/src/services/ServiceBase.js
+++ b/src/services/ServiceBase.js
@@ -144,7 +144,15 @@ class ServiceBase {
   async getAccessToken () {
     Promise.reject('this must be overridden !');
   }
+  /**
+   * Check if the authentificate is done
+   * @returns {Boolean} - True if authentificate
+   */
   async isAuthentificate () {
+    // only for remote mode !
+    if (this.mode === "local") {
+      return false;
+    }
     var data = await this.getUserMe();
     return (data !== null);
   }

--- a/src/services/ServiceBase.js
+++ b/src/services/ServiceBase.js
@@ -144,6 +144,10 @@ class ServiceBase {
   async getAccessToken () {
     Promise.reject('this must be overridden !');
   }
+  async isAuthentificate () {
+    var data = await this.getUserMe();
+    return (data !== null);
+  }
 }
 
 // Mixin

--- a/src/services/ServiceUsers.js
+++ b/src/services/ServiceUsers.js
@@ -63,10 +63,14 @@ var Users = {
           "X-Requested-With" : "XMLHttpRequest"
         }
       });
-      var data = await response.json();
-      this.user = data;
-      
-      this.saveStore();
+
+      var data = null;
+      if (response.status === 200) {
+        data = await response.json();
+        this.user = data;
+        
+        this.saveStore();
+      }
   
       return data;
     } catch (error) {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -79,6 +79,22 @@ const mandatoryLinks = computed(() => {
 
 var service :any = inject('services');
 
+service.isAuthentificate()
+.then((status:boolean) => {
+  // le service renvoie un user 
+  // et on n'est pas authentifié sur la carto
+  if (status && !service.authenticated && service.mode === "remote") {
+    router.push({ path : '/login?success=1' });
+  }
+  // le service ne renvoie rien (401 Unauthorized)
+  // et on est encore enregistré comme authentifié
+  if (!status && service.authenticated && service.mode === "remote") {
+    router.push({ path : '/logout?success=1' });
+  }
+})
+.catch()
+.finally();
+
 // INFO
 // on teste si une demande de connexion (ou de deconnexion) a été faite,
 // et si elle est valide, on demande le jeton de connexion, puis,

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -82,12 +82,14 @@ var service :any = inject('services');
 service.isAuthentificate()
 .then((status:boolean) => {
   // le service renvoie un user 
-  // et on n'est pas authentifié sur la carto
+  // mais on n'est pas authentifié sur la carto
+  // --> sync
   if (status && !service.authenticated && service.mode === "remote") {
     router.push({ path : '/login?success=1' });
   }
   // le service ne renvoie rien (401 Unauthorized)
-  // et on est encore enregistré comme authentifié
+  // mais, on est encore enregistré comme authentifié
+  // --> sync
   if (!status && service.authenticated && service.mode === "remote") {
     router.push({ path : '/logout?success=1' });
   }


### PR DESCRIPTION
**Hack** uniquement valable sur un même navigateur (donc même session) !
- Si on est connecté sur "cartes.gouv.fr", le passage à l'entrée carto doit mettre à jour l'authentification : _le nom apparaît_.
- Si on est déconnecté sur "cartes.gouv.fr", le passage à l'entrée carto doit mettre à jour l'authentification : _le nom n'apparaît pas_.

Comment recetter ?
``` bash
$ docker compose -f .docker-dev/docker-compose.yml watch

[+] Running 4/4
 ✔ entree_carto_dev                               Built
 ✔ Container cartesgouvfr-dev               Running 
 ✔ Container cartesgouvfr-nginx_proxy-dev   Started
 ✔ Container cartesgouvfr-entree_carto-dev  Started 
```
Puis, ouvrir le navigateur **Firefox** sur l'url suivante : http://localhost:1235

**Note:**
> Ceci est un hack !
> Pour une gestion des auth, il faudrait une solution via un redis de session au niveau de nos serveurs...