### PR TITLE
Type de permalien qui permet de compléter une config

### DIFF
--- a/src/composables/urlParams.js
+++ b/src/composables/urlParams.js
@@ -66,6 +66,10 @@ export function useUrlParams(url) {
             break;
           case "p":
             params.geolocation = urlParams[key];
+            break;
+          case "permalink":
+            params.permalink = urlParams[key]; // yes | no
+            break;
           default:
             break;
         }


### PR DESCRIPTION
2 types de permaliens
- avec le tag `permalink=yes` : fonctionnement natif, la configuration en cours est entièrement replacée
- avec le tag `permalink=no`  : la configuration en cours est complétée à celle qui existe

**Pour recetter**

Ajouter plusieurs couches, puis charger ce permalien :
`http://localhost:5173/cartes.gouv.fr-entree-carto?c=2.602777,46.493888&z=6&l=BDCARTO-HYDROGRAPHIE_WLD_WGS84G$GEOPORTAIL:OGC:WMS(1;1;1;0),HYDROGRAPHY.BCAE.2021$GEOPORTAIL:OGC:WMTS(2;1;1;0)&w=&permalink=no`
> ces 2 couches devraient apparaître au dessus