### PR TITLE
Fix sur les emprises sur le zoomToExtent pour les TMS

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -1,13 +1,10 @@
 # Unreleased
 
-<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.8...HEAD>
+<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.9...HEAD>
 
-## 🔖 version 1.0.8 - __DATE__
+## 🔖 version 1.0.9 - __DATE__
 
 ### 🎉 Résumé
-
-Ajout de la fonctionnalité de signalement accessible depuis le menu contextuel (clic droit) ou le menu carte en haut à gauche. Reprise du design des boutons, du footer, et de la fenêtre de consentement.
-Branchement de la configuration du cartalogue au service de recherche de la Géoplateforme, et utilisation d'une clé d'accès dédiée pour les offres sur la route private.
 
 ### 💥 Breaking changes
 
@@ -15,16 +12,7 @@ Branchement de la configuration du cartalogue au service de recherche de la Géo
 
 #### ✨ [Ajout]
 
-- Signalement : Outil de signalement d'anomalie accessible depuis le menu carte ou le menu contextuel (#622) 
-
 #### 🔨 [Evolution]
-
-- Espace Personnel : en mode connecté, enregistrement automatique des imports de données vectorielles (#603)
-- Partage : réduction du nombre de chiffres après la virgule des coordonnées (#617)
-- Partage : retrait des widgets permanents du permalien (#625)
-- UI : redesign des boutons (#618, #619)
-- Configuration : Gestion homogène des messages d'alertes en cas d'incidents ou d'informations à afficher (#624)
-- Consentement : Mise à jour de la fenêtre de consentement au format standard de cartes.gouv (#626)
 
 #### 🔥 [Obsolète]
 
@@ -32,11 +20,7 @@ Branchement de la configuration du cartalogue au service de recherche de la Géo
 
 #### 🐛 [Correction]
 
-- Partage : prise en compte du style pour les couches TMS dans le lien de partage (#610)
-- Notifications : correction de l'affichage de notifications intempestives en cas de donnée inexistante au chargement (e8e2131e32ba264b6fe15e91c7966f5d3e3007e1)
-- Plein Écran : correctif pour garder tous les boutons de la carte en pleine écran (79637fe8730235d7fd2e5f60c48597e0cafea808)
-- Footer : mise en conformité du footer réduit en mode dépliable (#620)
-- UI : décalage dans l'alignement des boutons (#623)
+  - LayerSwitcher : correction de la prise en compte des emprises exprimées dans des systèmes de coordonnées autres que 4326 (#642)
 
 #### 🔒 [Sécurité]
 

--- a/env/.env.docker-local
+++ b/env/.env.docker-local
@@ -1,7 +1,7 @@
 VITE_GPF_CONTEXT="docker-dev-local"
 # variables are statically replaced at build time !
-VITE_GPF_CONF_ALERTS="data/alerts.json"
-VITE_GPF_CONF_ENTREE_CARTO="data/entreeCarto.json"
+VITE_GPF_CONF_ALERTS="https://data.geopf.fr/annexes/cartes.gouv.fr-config/public/alerts.json"
+VITE_GPF_CONF_ENTREE_CARTO="https://raw.githubusercontent.com/IGNF/geoportal-configuration/new-url/dist/entreeCarto.json"
 
 VITE_GPF_BASE_URL_EXTERNAL="https://cartes.gouv.fr"
 VITE_GPF_BASE_URL_DOCUMENT="https://data.geopf.fr/documents/"

--- a/src/components/carte/control/LayerSwitcher.vue
+++ b/src/components/carte/control/LayerSwitcher.vue
@@ -244,7 +244,8 @@ const onZoomToExtentLayer = (e) => {
         globalConstraints.extent.top
       ];
 
-      var crsSource = globalConstraints.crs;
+      var crsSource = globalConstraints.projection;
+      // par défaut, les projections devraient être en Geographique
       if (!crsSource) {
         crsSource = "EPSG:4326";
       }

--- a/src/stores/dataStore.js
+++ b/src/stores/dataStore.js
@@ -276,7 +276,9 @@ export const useDataStore = defineStore('data', () => {
       // get layer configuration object
       var l = this.getLayerByID(id);
       params = {};
-      params.projection = l.defaultProjection;
+      // par défaut, les projections devraient être en Geographique
+      // sauf si renseignée
+      params.projection = l.globalConstraint.crs; 
       params.minScale = l.globalConstraint.minScaleDenominator;
       params.maxScale = l.globalConstraint.maxScaleDenominator;
       params.extent = l.globalConstraint.bbox;


### PR DESCRIPTION
Les **globalConstraints** fournies par le service de configuration précisent l'emprise de la donnée : 
```js
globalConstraint: {
  crs: "EPSG:3857",
  bbox: {
    left: 222569.48368345576,
    right: 653827.9949274634,
    top: 6491207.83699174,
    bottom: 6097028.181821302
  },
  minScaleDenominator: 279541132.01435894,
  maxScaleDenominator: 2132.7295838497826
}
```

On utilise la projection de la **globalConstraint** pour réaliser une reprojection (si nécessaire) dans le système de la carte.

Si la projection n'est pas renseignée dans la **globalConstraint**, on estime que l'emprise est en géographique (EPSG:4326).