### PR TITLE
Correctif du consentement suite à la recette

### DIFF
--- a/src/components/modals/ModalConsentCustom.vue
+++ b/src/components/modals/ModalConsentCustom.vue
@@ -90,17 +90,8 @@ onUpdated(() => {
     @close="onModalConsentCustomClose"
   >
     <!-- slot : c'est ici que l'on customise le contenu ! -->
-    <p id="my-consent-custom" ref="refConsent">
-      <DsfrConsent
-        @accept-all="onAcceptConsentAll()"
-        @refuse-all="onRefuseConsentAll()"
-      >
-        Préférences pour tous les services.
-        <a :href="url">Données personnelles et cookies</a>
-      </DsfrConsent>
-    </p>
     <hr>
-    <div>
+    <div id="my-consent-description">
       <h5>Eulerian Analytics</h5>
       En cliquant sur 'Tout accepter', vous consentez à l'utilisation des cookies pour nous aider
       à améliorer notre site web en collectant et en rapportant des informations sur votre
@@ -108,13 +99,22 @@ onUpdated(() => {
       Si vous n'êtes pas d'accord, veuillez cliquer sur 'Tout refuser'. 
       Votre expérience de navigation ne sera pas affectée.
     </div>
-    <div class="fr-consent-manager__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-sm">
-      <DsfrButton
-        @click="onClickValideChoice"
-      >
+    <div>
+      <p id="my-consent-buttons" ref="refConsent">
+        <DsfrConsent
+        @accept-all="onAcceptConsentAll()"
+        @refuse-all="onRefuseConsentAll()"
+        >
+        Préférences pour tous les services.
+        <a :href="url">Données personnelles et cookies</a>
+        </DsfrConsent>
+      </p>
+    </div>
+    <!-- <div class="fr-consent-manager__buttons fr-btns-group fr-btns-group--center fr-btns-group--inline-sm">
+      <DsfrButton @click="onClickValideChoice">
         Confirmer mes choix
       </DsfrButton>
-    </div>
+    </div> -->
   </DsfrModal>
 </template>
 
@@ -122,8 +122,11 @@ onUpdated(() => {
 /* Surcharge sur le composant DsfrConsent : 
   > on n'affiche pas le bouton 'Personnaliser les cookies' 
 */
-#my-consent-custom button[title="Personnaliser les cookies"] {
+#my-consent-buttons button[title="Personnaliser les cookies"] {
   display: none;
+}
+#my-consent-description {
+  padding-bottom: 1em;
 }
 /* Surcharge sur le composant DsfrConsent : 
   > on centre les boutons 


### PR DESCRIPTION
Recette 

le bouton "confirmer mes choix" est supprimé, et les boutons sont placés à la fin.
![image](https://github.com/user-attachments/assets/0f03b660-50e6-491f-a333-0a3761646f42)


