### PR TITLE
ui(controllist): ne change plus d'emplacement en fonction de la taille de l'écran

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -1,13 +1,10 @@
 # Unreleased
 
-<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.8...HEAD>
+<https://github.com/IGNF/cartes.gouv.fr-entree-carto/compare/v1.0.9...HEAD>
 
-## 🔖 version 1.0.8 - __DATE__
+## 🔖 version 1.0.9 - __DATE__
 
 ### 🎉 Résumé
-
-Ajout de la fonctionnalité de signalement accessible depuis le menu contextuel (clic droit) ou le menu carte en haut à gauche. Reprise du design des boutons, du footer, et de la fenêtre de consentement.
-Branchement de la configuration du cartalogue au service de recherche de la Géoplateforme, et utilisation d'une clé d'accès dédiée pour les offres sur la route private.
 
 ### 💥 Breaking changes
 
@@ -15,36 +12,15 @@ Branchement de la configuration du cartalogue au service de recherche de la Géo
 
 #### ✨ [Ajout]
 
-- Signalement : Outil de signalement d'anomalie accessible depuis le menu carte ou le menu contextuel (#622)
-- Partage : nouveau type de permalien pour compléter la configuration existante enregistrée dans le localStorage (#641)
-
 #### 🔨 [Evolution]
-
-- Espace Personnel : en mode connecté, enregistrement automatique des imports de données vectorielles (#603)
-- Partage : réduction du nombre de chiffres après la virgule des coordonnées (#617)
-- Partage : retrait des widgets permanents du permalien (#625)
-- UI : redesign des boutons (#618, #619)
-- Configuration : Gestion homogène des messages d'alertes en cas d'incidents ou d'informations à afficher (#624)
-- Consentement : Mise à jour de la fenêtre de consentement au format standard de cartes.gouv (#626)
-- Connexion : synchronisation de la connexion avec les autres pages de cartes.gouv (#640)
-- Espace Personnel : ajout d'un bouton dans l'espace personnel pour directement copier ses cartes (#649)
 
 #### 🔥 [Obsolète]
 
 #### 🔥 [Suppression]
 
-- Partage : retrait des widgets permanents du permalien (#625) 
-
 #### 🐛 [Correction]
 
-- Partage : prise en compte du style pour les couches TMS dans le lien de partage (#610)
-- Notifications : correction de l'affichage de notifications intempestives en cas de donnée inexistante au chargement (e8e2131e32ba264b6fe15e91c7966f5d3e3007e1)
-- Plein Écran : correctif pour garder tous les boutons de la carte en pleine écran (79637fe8730235d7fd2e5f60c48597e0cafea808)
-- Footer : mise en conformité du footer réduit en mode dépliable (#620)
-- UI : décalage dans l'alignement des boutons (#623)
-- Configuration : Utilisation d’une clé d’accès dédiée (81aed043c6e6f75553e09b01684eb929a9868687) 
-- LayerSwitcher : correction de la fonctionnalité de centrage sur emprise en cas de contraintes non exprimées en 4326 (#642) 
-- Geocodage Inverse : correction de la recherche par cercle (#643) 
+- Widgets Additionnels (UI) : le bouton permettant d'accéder aux widgets additionnels reste toujours sous la liste des widgets optionnel même en mode mobile (#664) 
 
 #### 🔒 [Sécurité]
 

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -662,14 +662,38 @@ const contextMenuOptions = computed(() => {
 /* TODO: max-height: 639px carto sera plus grande (header et footer réduits) */
 /* Que le menu +, pas de controls */
 @media (max-height: 739px) {
-  .position-container-top-right > .gpf-widget:nth-child(n+3) > button {
+  .position-container-top-right > .gpf-widget:nth-child(n+4) > button {
     display: none;
+  }
+
+  .position-container-top-right > div:nth-child(n+4) {
+    margin: 0;
+    padding: 0;
+  }
+
+  .position-container-top-right:has(.gpf-widget:nth-child(5)) > .gpf-widget:not([id^="GPcontrolList-"]):nth-child(n+3) > button {
+    display: none;
+  }
+
+  .position-container-top-right:has(.gpf-widget:nth-child(5)) > .gpf-widget:not([id^="GPcontrolList-"]):nth-child(n+3) {
+    margin: 0;
+    padding: 0;
+  }
+
+  .position-container-top-right:has(.gpf-widget:nth-child(5)) > .gpf-widget[id^="GPcontrolList-"] > button {
+    display: inline-flex;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+
+  .position-container-top-right:has(.gpf-widget:nth-child(5)) > .gpf-widget[id^="GPcontrolList-"] {
+    padding: 2px;
   }
 }
 
 /* TODO: max-height: 719px carto sera plus grande (header et footer réduits) */
 /* 4 controls optionnels */
-@media (max-height: 819px) {
+@media (min-height: 740px) and (max-height: 819px) {
   .position-container-top-right > .gpf-widget:nth-child(n+7) > button {
     display: none;
   }
@@ -708,7 +732,7 @@ const contextMenuOptions = computed(() => {
 
 /* TODO: max-height: 779px carto sera plus grande (header et footer réduits) */
 /* 6 controls optionnels */
-@media (max-height: 919px) {
+@media (min-height: 820px) and (max-height: 919px) {
   .position-container-top-right > .gpf-widget:nth-child(n+9) > button {
     display: none;
   }
@@ -747,7 +771,7 @@ const contextMenuOptions = computed(() => {
 
 /* TODO: max-height: 859px carto sera plus grande (header et footer réduits) */
 /* 8 controls optionnels */
-@media (max-height: 999px) {
+@media (min-height: 920px) and (max-height: 999px) {
   .position-container-top-right > .gpf-widget:nth-child(n+11) > button {
     display: none;
   }

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -655,18 +655,6 @@ const contextMenuOptions = computed(() => {
   padding: 2px;
 }
 
-/* Cas particuliers pour éviter les coins non arrondis autour de l'import qui est caché (uniquement sur l'entree carto) */
-.gpf-button-no-gutter:has(+ .gpf-button-no-gutter:not([id^="GPimport-"])) > .gpf-btn-icon {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.gpf-button-no-gutter[id^="GPimport-"] + .gpf-button-no-gutter:not([id^="GPimport-"]) > .gpf-btn-icon {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-
-.gpf-button-no-gutter:has(+ .gpf-button-no-gutter[id^="GPimport-"]) > .gpf-btn-icon,
 .gpf-button-no-gutter:has(+ .gpf-widget-button[id^="GPcontrolList-"]) > .gpf-btn-icon {
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
@@ -829,8 +817,22 @@ const contextMenuOptions = computed(() => {
     max-height: calc(100% + 258px);
   }
 
-  .position-container-top-right > .gpf-widget:nth-child(n+3) > button {
+  .position-container-top-right > .gpf-widget:nth-child(n+4) > button {
     display: none;
+  }
+
+  .position-container-top-right:has(.gpf-widget:nth-child(5)) > .gpf-widget:not([id^="GPcontrolList-"]):nth-child(n+3) > button {
+    display: none;
+  }
+
+  .position-container-top-right:has(.gpf-widget:nth-child(5)) > .gpf-widget[id^="GPcontrolList-"] > button {
+    display: inline-flex;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+
+  .position-container-top-right:has(.gpf-widget:nth-child(5)) > .gpf-widget[id^="GPcontrolList-"] {
+    padding: 2px;
   }
 
   .position-container-bottom-left {

--- a/src/components/carte/control/ControlList.vue
+++ b/src/components/carte/control/ControlList.vue
@@ -20,26 +20,27 @@ const log = useLogger()
 const map = inject(props.mapId)
 const controlList = ref(new ControlList(props.controlListOptions))
 
-const isSmallScreen = useMatchMedia('SM')
-const isSmallHeight = useMatchMediaHeight('XS')
+// REMOVEME : le bouton "+" ne descend plus quand l'écran est petit. Commenté au cas-où on re-change d'avis
+// const isSmallScreen = useMatchMedia('SM')
+// const isSmallHeight = useMatchMediaHeight('XS')
 
-watch(isSmallScreen, () => {
-  if (props.visibility && !isSmallScreen.value && !isSmallHeight.value) {
-    controlList.value.setPosition("top-right")
-  }
-  else {
-    controlList.value.setPosition("bottom-right")
-  }
-})
+// watch(isSmallScreen, () => {
+//   if (props.visibility && !isSmallScreen.value && !isSmallHeight.value) {
+//     controlList.value.setPosition("top-right")
+//   }
+//   else {
+//     controlList.value.setPosition("bottom-right")
+//   }
+// })
 
-watch(isSmallHeight, () => {
-  if (props.visibility && !isSmallScreen.value && !isSmallHeight.value) {
-    controlList.value.setPosition("top-right")
-  }
-  else {
-    controlList.value.setPosition("bottom-right")
-  }
-})
+// watch(isSmallHeight, () => {
+//   if (props.visibility && !isSmallScreen.value && !isSmallHeight.value) {
+//     controlList.value.setPosition("top-right")
+//   }
+//   else {
+//     controlList.value.setPosition("bottom-right")
+//   }
+// })
 
 watch(selectedControls, () => {
   setTimeout(() => {
@@ -50,12 +51,13 @@ watch(selectedControls, () => {
         var el = controlList.value.element.querySelector("button[id^=GPshowControlListPicto-]");
         useActionButtonEulerian(el);
       }
-      if (!isSmallScreen.value && !isSmallHeight.value) {
-        controlList.value.setPosition("top-right")
-      }
-      else {
-        controlList.value.setPosition("bottom-right")
-      }
+      // REMOVEME : le bouton "+" ne descend plus quand l'écran est petit. Commenté au cas-où on re-change d'avis
+      // if (!isSmallScreen.value && !isSmallHeight.value) {
+      //   controlList.value.setPosition("top-right")
+      // }
+      // else {
+      //   controlList.value.setPosition("bottom-right")
+      // }
     }
   }, 10);
 })

--- a/src/components/carte/control/ControlList.vue
+++ b/src/components/carte/control/ControlList.vue
@@ -1,6 +1,7 @@
 <script setup lang="js">
 import { useActionButtonEulerian } from '@/composables/actionEulerian.js';
-import { useMatchMedia, useMatchMediaHeight } from '@/composables/matchMedia';
+// REMOVEME : le bouton "+" ne descend plus quand l'écran est petit. Commenté au cas-où on re-change d'avis
+// import { useMatchMedia, useMatchMediaHeight } from '@/composables/matchMedia';
 import { useLogger } from 'vue-logger-plugin'
 import {
   ControlList

--- a/src/composables/controls.js
+++ b/src/composables/controls.js
@@ -371,10 +371,10 @@ export function useControlsExtensionPosition() {
     measureAreaOptions : 'top-right',
     measureAzimuthOptions : 'top-right',
     elevationPathOptions : 'top-right',
-    layerImportOptions : 'top-right',
+    layerImportOptions : 'top-left',
     mousePositionOptions : 'top-right',
     drawingOptions : 'top-right',
-    reportingOptions : 'top-right'
+    reportingOptions : 'top-left'
   }
 }
 
@@ -400,22 +400,22 @@ export function useControlsPosition() {
   if (useControlsExtensionPosition().legendsOptions.includes("left"))
     leftC.push(useControls.Legends.id)
   if (useControlsExtensionPosition().legendsOptions.includes("right"))
-    rightC.push(useControls.Legends.id)  
+    rightC.push(useControls.Legends.id)
   // Route
   if (useControlsExtensionPosition().routeOptions.includes("left"))
     leftC.push(useControls.Route.id)
   if (useControlsExtensionPosition().routeOptions.includes("right"))
-    rightC.push(useControls.Route.id)    
+    rightC.push(useControls.Route.id)
   // Isocurve
   if (useControlsExtensionPosition().isocurveOptions.includes("left"))
     leftC.push(useControls.Isocurve.id)
   if (useControlsExtensionPosition().isocurveOptions.includes("right"))
-    rightC.push(useControls.Isocurve.id) 
+    rightC.push(useControls.Isocurve.id)
   // ReverseGeocode
   if (useControlsExtensionPosition().reverseGeocodeOptions.includes("left"))
     leftC.push(useControls.ReverseGeocode.id)
   if (useControlsExtensionPosition().reverseGeocodeOptions.includes("right"))
-    rightC.push(useControls.ReverseGeocode.id) 
+    rightC.push(useControls.ReverseGeocode.id)
   // ReverseGeocode
   if (useControlsExtensionPosition().drawingOptions.includes("left"))
     leftC.push(useControls.Drawing.id)
@@ -425,42 +425,42 @@ export function useControlsPosition() {
   if (useControlsExtensionPosition().getFeatureInfoOptions.includes("left"))
     leftC.push(useControls.GetFeatureInfo.id)
   if (useControlsExtensionPosition().getFeatureInfoOptions.includes("right"))
-    rightC.push(useControls.GetFeatureInfo.id)  
+    rightC.push(useControls.GetFeatureInfo.id)
   // Territories
   if (useControlsExtensionPosition().territoriesOptions.includes("left"))
     leftC.push(useControls.Territories.id)
   if (useControlsExtensionPosition().territoriesOptions.includes("right"))
-    rightC.push(useControls.Territories.id) 
+    rightC.push(useControls.Territories.id)
   // MeasureLength
   if (useControlsExtensionPosition().measureLengthOptions.includes("left"))
     leftC.push(useControls.MeasureLength.id)
   if (useControlsExtensionPosition().measureLengthOptions.includes("right"))
-    rightC.push(useControls.MeasureLength.id) 
+    rightC.push(useControls.MeasureLength.id)
   // MeasureArea
   if (useControlsExtensionPosition().measureAreaOptions.includes("left"))
     leftC.push(useControls.MeasureArea.id)
   if (useControlsExtensionPosition().measureAreaOptions.includes("right"))
-    rightC.push(useControls.MeasureArea.id) 
+    rightC.push(useControls.MeasureArea.id)
   // MeasureAzimuth
   if (useControlsExtensionPosition().measureAzimuthOptions.includes("left"))
     leftC.push(useControls.MeasureAzimuth.id)
   if (useControlsExtensionPosition().measureAzimuthOptions.includes("right"))
-    rightC.push(useControls.MeasureAzimuth.id) 
+    rightC.push(useControls.MeasureAzimuth.id)
   // MousePosition
   if (useControlsExtensionPosition().mousePositionOptions.includes("left"))
     leftC.push(useControls.MousePosition.id)
   if (useControlsExtensionPosition().mousePositionOptions.includes("right"))
-    rightC.push(useControls.MousePosition.id) 
+    rightC.push(useControls.MousePosition.id)
   // ElevationPath
   if (useControlsExtensionPosition().elevationPathOptions.includes("left"))
     leftC.push(useControls.ElevationPath.id)
   if (useControlsExtensionPosition().elevationPathOptions.includes("right"))
-    rightC.push(useControls.ElevationPath.id) 
+    rightC.push(useControls.ElevationPath.id)
   // LayerImport
   if (useControlsExtensionPosition().layerImportOptions.includes("left"))
     leftC.push(useControls.LayerImport.id)
   if (useControlsExtensionPosition().layerImportOptions.includes("right"))
-    rightC.push(useControls.LayerImport.id) 
+    rightC.push(useControls.LayerImport.id)
   // ControlList
   if (useControlsExtensionPosition().controlListOptions.includes("left"))
     leftC.push(useControls.ControlList.id)


### PR DESCRIPTION
fixes https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/638

\+ une partie de https://github.com/IGNF/cartes.gouv.fr-entree-carto/issues/650
> Lorsqu'un seul outil d'activé, afficher celui-ci systématiquement et jamais le widget additionnel
