### PR TITLE
fix(espace-perso): chargement cartes enregistrée, cf #698

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,8 @@
 
 #### 🐛 [Correction]
 
+  - Espace Perso : correction du #698 pour le chargement des cartes enregistrées (#701)
+
 #### 🔒 [Sécurité]
 
 ---

--- a/src/composables/urlParams.js
+++ b/src/composables/urlParams.js
@@ -2,7 +2,7 @@ import { useUrlSearchParams } from '@vueuse/core';
 import {
   fromLonLat as fromLonLatProj
 } from "ol/proj";
-
+import { useDefaultControls } from '@/composables/controls';
 /**
  * Lecture du permalink pour y extraire les informations.
  * La structure est identique au permalien de la carte
@@ -56,7 +56,7 @@ export function useUrlParams(url) {
             params.layers = urlParams[key];
             break;
           case "w":
-            params.controls = urlParams[key];
+            params.controls = urlParams[key] + "," + useDefaultControls().toString();
             break;
           case "d":
             params.bookmarks = urlParams[key];


### PR DESCRIPTION
## Pull request checklist

Verifiez que votre Pull Request remplit les conditions suivantes :
- [ ] Des tests ont été ajoutés pour les changements (corrections de bugs ou features)
- [ ] De la documentation a été mise à jour ou ajoutée si nécessaire (corrections de bugs ou features)
- [x] Un build (`npm run build`) a été lancé localement et s'est correctement déroulé
- [ ] Les exemples impactés par les modifications (`npm run samples`) ont été testés et validés localement
- [ ] Les tests (`npm run test`) sont passés localement


## Type de Pull request

<!-- Attention à ne pas mettre à jour les dépendances, à moins que ce soit l'objet de la PR --> 

<!-- Essayer autant que faire se peut de se limiter à un type de changement par PR. --> 

Quel type de changement cette Pull Request introduit-elle :
- [x] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [ ] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 


## Quel est le comportement actuel (avant PR) :
Charger une carte enregistrée. Les widgets permanents ayant été retirés des permaliens (#625), ils ne sont pas chargées : l'interface ne propose plus le layerSwitcher et les autres widgets permanents au chargement d'une carte enregistrée.

Numéro du ticket : #698


## Quel est le nouveau comportement :
<!-- Décrire le comportement ou les changements ajoutés par cette PR -->
Au chargement d'un permalien, on ajoute les widgets par défaut à la liste du paramètres widgets. Les widgets par défaut sont ainsi bien chargés.

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non


