### PR TITLE
fix(position:widgets): alignement top-left des panels des widgets botom-left

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -12,6 +12,8 @@
 
 #### ✨ [Ajout]
 
+  - Geocodage inverse : possibilité de copier le résultat (#705)
+
 #### 🔨 [Evolution]
 
   - Menu des Widgets : mise à jour de la présentation de la liste des widgets et de leur description (#687)

--- a/src/components/carte/control/Legends.vue
+++ b/src/components/carte/control/Legends.vue
@@ -40,4 +40,11 @@ onBeforeUpdate(() => {
   <!-- TODO ajouter l'emprise du widget pour la gestion des collisions -->
 </template>
 
-<style></style>
+<style>
+/*
+VERRUE : pour les widgets dont les boutons sont bottom-left, on veut aligner les panels avec le container top-left
+*/
+dialog[id^=GPlegendsPanel-] {
+  top : -85px !important;
+}
+</style>

--- a/src/components/carte/control/Territories.vue
+++ b/src/components/carte/control/Territories.vue
@@ -75,6 +75,13 @@ onUpdated(() => {
 </template>
 
 <style>
+/*
+VERRUE : pour les widgets dont les boutons sont bottom-left, on veut aligner les panels avec le container top-left
+*/
+dialog[id^=GPterritoriesPanel-] {
+  top : -85px !important;
+}
+
   @media (max-width: 576px){
     .gpf-panel__body_territories {
       max-height: calc(100vh - 92.5px - 56px);


### PR DESCRIPTION
Les panels des widgets situés en bas à gauche (teritories + legendes) s'alignent verticalement avec les panels en haut à gauche.

*Je suis preneur si vous avez une solution plus propre pour se passer du !important :-1:**
## Quel est le comportement actuel (avant PR) :

<img width="772" height="795" alt="image" src="https://github.com/user-attachments/assets/50578b8d-9012-4bc4-ae0c-a0145d0549ff" />

<img width="772" height="795" alt="image" src="https://github.com/user-attachments/assets/43c0f15b-bb9e-4e03-95b9-eaa1041b5370" />


## Quel est le nouveau comportement :

<img width="772" height="795" alt="Capture d’écran du 2025-09-26 13-45-47" src="https://github.com/user-attachments/assets/8eae6c2e-4f34-486b-acbf-1d68c04c0d32" />

<img width="772" height="795" alt="image" src="https://github.com/user-attachments/assets/ec85d14c-2c5f-4fce-838d-a69fa2cce9d2" />

## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

Lié aux évols du #704 #705