### PR TITLE
Ajout d'une configuration pour la 'View' & 'Map'

### DIFF
--- a/src/components/carte/Map.vue
+++ b/src/components/carte/Map.vue
@@ -13,6 +13,14 @@ export default {
 import { CRS } from 'geopf-extensions-openlayers'
 
 import Map from 'ol/Map'
+import {
+    MouseWheelZoom,
+    defaults as defaultInteractions
+} from "ol/interaction";
+import {
+    shiftKeyOnly as eventShiftKeyOnly
+} from "ol/events/condition";
+
 import { useMapStore } from "@/stores/mapStore"
 import { mainMap } from "@/composables/keys"
 
@@ -33,7 +41,13 @@ const mapRef = ref(null)
 */
 const map = new Map({
   target: props.mapId,
-  controls: [] // on supprime les contrôles par defaut !
+  controls: [], // on supprime les contrôles par defaut !
+  interactions : defaultInteractions().extend([
+    new MouseWheelZoom({
+      constrainResolution : true,
+      condition : eventShiftKeyOnly
+    })
+  ]),
 })
 
 /**

--- a/src/components/carte/View.vue
+++ b/src/components/carte/View.vue
@@ -37,7 +37,10 @@ const map = inject(props.mapId);
  */
 const view = new View({ 
   zoom: props.zoom, 
-  center: fromLonLatProj(props.center)
+  center: fromLonLatProj(props.center),
+  minZoom : 0,
+  maxZoom : 21,
+  projection : "EPSG:3857"
 });
 
 /**


### PR DESCRIPTION
cf. issue #771 

Ajout d'une configuration minimum

```js
/**
 * creation de la vue
 */
const view = new View({ 
  zoom: props.zoom, 
  center: fromLonLatProj(props.center),
  minZoom : 0,
  maxZoom : 21,
  projection : "EPSG:3857"
});
```

```js
/**
* Map
* default controls are removed (rotate, zoom and attributions)
*/
const map = new Map({
  target: props.mapId,
  controls: [], // on supprime les contrôles par defaut !
  interactions : defaultInteractions().extend([
    new MouseWheelZoom({
      constrainResolution : true,
      condition : eventShiftKeyOnly
    })
  ]),
})
```