### PR TITLE
fix context menu mobile

### DIFF
--- a/src/components/carte/control/ContextMenu.vue
+++ b/src/components/carte/control/ContextMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="js">
 import { ContextMenu } from 'geopf-extensions-openlayers';
+import { useMatchMedia } from '@/composables/matchMedia';
 
 const props = defineProps({
   mapId: String,
@@ -8,12 +9,19 @@ const props = defineProps({
   contextMenuOptions: Object
 });
 
+const isSmallScreen = useMatchMedia('SM')
+
 const map = inject(props.mapId)
 const contextMenu = ref(new ContextMenu(props.contextMenuOptions));
-
+const pixel = ref([0,0])
 onMounted(() => {
   if (props.visibility) {
     map.addControl(contextMenu.value);
+    contextMenu.value.contextmenu.on("open", onContextMenuOpen)
+    map.on('singleclick', function (evt) {
+    const pixel = evt.pixel;
+      pixel.value =[90, pixel[1]]
+    });
   }
 })
 
@@ -25,6 +33,12 @@ onBeforeUpdate(() => {
     map.removeControl(contextMenu.value);
   }
 })
+
+const onContextMenuOpen = () => {
+  if (isSmallScreen.value) {
+    contextMenu.value.contextmenu.updatePosition([90, pixel[1]])
+  }
+}
 </script>
 
 <template>


### PR DESCRIPTION
- fix position du menu contextuel en mode mobile.

Proposition : 
en mode mobile on fixe la position horizontale et on ne laisse que la position verticale varier. 
