### PR TITLE
Fix max-width media-queries

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -53,6 +53,7 @@ $widget-panel-x: $widget-btn-size + $gap * 2;
 
 // mq
 // min-width breakpoints
+// on retranche 0.01em pour les max-width
 $breakpoints: (
   xs: 0,
   sm: 36em, // 576
@@ -68,13 +69,13 @@ $breakpoints: (
 }
 
 @mixin max($bp) {
-  @media (max-width: map.get($breakpoints, $bp)) {
+  @media (max-width: map.get($breakpoints, $bp) - 0.01em) {
     @content;
   }
 }
 
 @mixin between($from, $to) {
-  @media (min-width: map.get($breakpoints, $from)) and (max-width: map.get($breakpoints, $to)) {
+  @media (min-width: map.get($breakpoints, $from)) and (max-width: map.get($breakpoints, $to) - 0.01em) {
     @content;
   }
 }

--- a/src/composables/matchMedia.js
+++ b/src/composables/matchMedia.js
@@ -7,15 +7,17 @@ import { useMediaQuery } from '@vueuse/core';
  */
 export function useMatchMedia(size) {
     // breakpoints définis par le DSFR
+    // mais en min-width uniquement, donc on retranche 1px
+    // car ici on utilise max-width
     var sizes = {
-        SM : "576px",
-        MD : "768px",
-        LG : "992px",
-        XL : "1440px"
+        SM : 576 - 1,
+        MD : 768 - 1,
+        LG : 992 - 1,
+        XL : 1440 - 1
     };
 
     if (sizes[size] !== undefined) {
-        const query = "(max-width: " + sizes[size] + ")";
+        const query = "(max-width: " + sizes[size] + "px)";
         return useMediaQuery(query)
     }
 };


### PR DESCRIPTION
Le DFSR utilise des media-queries en CSS, mais les valeurs sont pour `min-width`.
Dans notre code, on utilise à la fois `min-width` et `max-width`.
Pour éviter un rendu cassé aux valeurs fixes définies (768px, 992px), il faut éviter des min et max identiques. 
On retranche donc 1px ou 0.01em aux valeurs utilisées