### PR TITLE
Force les labels à gauche pour les toggle

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -19,6 +19,7 @@
   - Zoom: améliorations UI (fix #700)
   - Mini Carte: respect maquette (fix #794)
   - La modale informations (les alertes) est transformée en alerte, bandeau en haut de page (#906)
+  - Mise à jour des packages dsfr et vue-dsfr
 
 #### 🔥 [Obsolète]
 
@@ -31,6 +32,7 @@
   - Header : correction d'un lien d'aide dans le header et du bouton "Decouvrir cartes.gouv" (#947)
   - En mode mobile, le footer est intégré au header (#816)
   - Revue UI des widgets/boutons/panels (#964) (fix #672, #743, #844, #886, #888)
+  - Amélioration accessibilité toggle du header compact
 
 #### 🔒 [Sécurité]
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "ext:i": "rm -rf node_modules/geopf-extensions-openlayers package-lock.json && npm install --force"
   },
   "dependencies": {
-    "@gouvfr/dsfr": "~1.13.2",
-    "@gouvminint/vue-dsfr": "^8.12.1",
+    "@gouvfr/dsfr": "^1.14.4",
+    "@gouvminint/vue-dsfr": "^8.15.0",
     "@iconify/vue": "^4.3.0",
     "geopf-extensions-openlayers": "1.0.0-beta.9",
     "jspdf": "^4.1.0",

--- a/src/components/menu/ControlListElement.vue
+++ b/src/components/menu/ControlListElement.vue
@@ -66,7 +66,7 @@ onUpdated(() => {})
         :disabled="controlListElementOptions.disabled"
         :input-id="controlListElementOptions.id"
         :label="controlListElementOptions.label"
-        label-left
+        class="fr-toggle--label-left"
         no-text
         :hint="controlListElementOptions.hint"
         :model-value="selectedControlsModel === true || (Array.isArray(selectedControlsModel) && selectedControlsModel.includes(controlListElementOptions.name))"

--- a/src/components/menu/MenuTierce.vue
+++ b/src/components/menu/MenuTierce.vue
@@ -30,8 +30,6 @@ const emit = defineEmits([
   'onBookMarksOpen'
 ]);
 
-const isCompact = ref(domStore.getIsHeaderCompact())
-
 function onOpenControlReporting() {
   // on active le controle
   mapStore.addControl("Reporting");
@@ -58,29 +56,10 @@ function openControl(controlName) {
   })
 }
 
-function onToggleHeaderCompact() {
-  isCompact.value = !isCompact.value
-  domStore.setIsHeaderCompact(isCompact.value);
-}
-
-const icon = "mingcute:file-import-line"
-const defaultScale = 0.8325;
-const iconProps = computed(() => typeof icon === 'string'
-  ? { scale: defaultScale.value, name: icon }
-  : { scale: defaultScale.value, ...icon },
-);
-
 // INFO
 // on active / desactive le bouton "Mes enregistrements" selon
 // si on est authentifié ou pas
 var service = inject('services');
-var authenticatedValue = computed(() => service.authenticated);
-// INFO
-// on est sur un faux "disabled" du bouton
-// car on souhaite que les evenements soient toujours actifs
-const authenticatedClass = ref({
-  authenticatedProperty: !authenticatedValue.value
-});
 
 const BookmarksButton = ref(null)
 onMounted(() => {
@@ -94,7 +73,7 @@ onMounted(() => {
       <DsfrButton
         tertiary
         no-outline
-        :class="authenticatedClass"
+        :class="{'fr-btn--disabled': !service.authenticated }"
         icon="ri-bookmark-line"
         @click="$emit('onBookMarksOpen')"
       >
@@ -138,45 +117,35 @@ onMounted(() => {
     </DsfrButton>
     <hr>
 
-    <DsfrButton
-      tertiary
-      no-outline
-      icon="ri:layout-top-line"
-      @click="onToggleHeaderCompact"
-    >
-      <div class="compact-toggle">
-        Affichage compact
-        <DsfrToggleSwitch
-          v-model="isCompact"
-          no-text
-          label-left
-          @click.stop
-          @click="domStore.setIsHeaderCompact(!isCompact)"
-        />
-      </div>
-    </DsfrButton>
+    <div class="fr-btn fr-btn--tertiary-no-outline fr-btn--md fr-btn--icon-left fr-icon-layout-top-line">
+      <DsfrToggleSwitch
+        v-model="domStore.isHeaderCompact"
+        label="Affichage compact"
+        no-text
+        class="fr-toggle--label-left"
+      />
+    </div>
   </div>
 </template>
 
 <style scoped>
-.authenticatedProperty {
-  --hover: inherit;
-  --active: inherit;
-  background-color: transparent;
-  color: var(--text-disabled-grey);
+:deep(.fr-btn),
+:deep(.fr-toggle__label) {
+  font-size: 0.875rem;
+  color: var(--text-action-high-grey);
 }
 
-a {
-  text-decoration: none;
+.fr-btn--disabled {
+  color: var(--text-disabled-grey);
+
+  --idle: transparent;
+  --hover: inherit;
+  --active: inherit;
 }
+
 .container {
   display: flex;
   flex-direction: column;
-}
-
-:deep(button) {
-  font-size: 0.875rem;
-  color: var(--text-action-high-grey);
 }
 
 @media (max-width: 576px) {
@@ -189,10 +158,5 @@ a {
   .tierce-print {
     display: none;
   }
-}
-
-.compact-toggle {
-  display: flex;
-  justify-content: space-between;
 }
 </style>

--- a/src/stores/domStore.js
+++ b/src/stores/domStore.js
@@ -21,10 +21,6 @@ export const useDomStore = defineStore('dom', () => {
   var rightControlMenu = ref();
   var isHeaderCompact = useStorage(ns('isHeaderCompact'), false);
 
-  watch(isHeaderCompact, () => {
-    localStorage.setItem(ns('isHeaderCompact'), isHeaderCompact.value);
-  })
-
   function getBookmarksButton () {
     return BookmarksButton.value;
   }
@@ -53,13 +49,6 @@ export const useDomStore = defineStore('dom', () => {
     rightControlMenu.value = m;
   }
 
-  function getIsHeaderCompact () {
-    return isHeaderCompact.value;
-  }
-  function setIsHeaderCompact (m) {
-    isHeaderCompact.value = m;
-  }
-
   return {
     isHeaderCompact,
     menuCatalogueButton,
@@ -74,7 +63,5 @@ export const useDomStore = defineStore('dom', () => {
     setrightControlMenu,
     getleftControlMenu,
     setleftControlMenu,
-    getIsHeaderCompact,
-    setIsHeaderCompact
   }
 });


### PR DESCRIPTION
Le Dsfr + VueDsfr ont été mis à jour, et un changement nous impacte: il est maintenant déconseillé d'utiliser des labels à gauche pour les toggle => https://github.com/GouvernementFR/dsfr/pull/1225

En attendant un retour design et/ou SIG, on force quand même la classe.

J'en ai aussi profité pour rendre plus accessible le toggle du header compact (avant c'était un toggle dans un bouton)

Actuellement sur https://ignf.github.io/cartes.gouv.fr-entree-carto/
<img width="500" height="486" alt="image" src="https://github.com/user-attachments/assets/1b125c7c-6b5d-4725-8d12-8282cac5c945" />