### PR TITLE
Réduit le poids du CSS dans le build final avec purgeCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "vite": "^6.2.6",
     "vite-plugin-compression2": "^2.4.0",
     "vite-plugin-env-runtime": "./modules/vite-plugin-env-runtime-0.3.6.tgz",
+    "vite-plugin-purgecss": "^0.2.13",
     "vitest": "^3.1.2",
     "vue": "^3.5.13",
     "vue-logger-plugin": "^2.2.3",

--- a/src/components/header/CustomNavigationMenu.vue
+++ b/src/components/header/CustomNavigationMenu.vue
@@ -169,7 +169,7 @@ onBeforeUnmount(() => {});
               :href="link.to"
               :target="link.target"
               class="fr-link--icon-left fr-access__link fr-nav__link flex-start"
-              :class="'fr-icon' + link.icon?.replace('ri', '')"
+              :class="link.icon"
             >
               <!-- <VIcon :name="link.icon" size="1.5rem" class="fr-icon--grey-800" /> -->
               {{ link.text }}

--- a/src/composables/headerParams.js
+++ b/src/composables/headerParams.js
@@ -22,19 +22,19 @@ export function useHeaderParams() {
                   text: "Questions Fréquentes",
                   to: useBaseUrl() + '/aide/fr/',
                   target: "_blank",
-                  icon: "ri-question-mark"
+                  icon: "fr-icon-question-mark"
               },
               {
                   text: "Guide d'utilisation",
                   to: useBaseUrl() + '/aide/fr/guides-utilisateur/visualiseur-cartographique/generalites-visualiseur/',
                   target: "_blank",
-                  icon: "ri-book-2-line"
+                  icon: "fr-icon-book-2-line"
               },
               {
                   text: "Nous contacter",
                   to: useBaseUrl() + '/nous-ecrire',
                   target: "_blank",
-                  icon: "ri-mail-line"
+                  icon: "fr-icon-mail-line"
               }
             ]   
           },  
@@ -45,17 +45,17 @@ export function useHeaderParams() {
               {
                   text: "Explorer les cartes",
                   to: useBaseUrl() + '/explorer-les-cartes',
-                  icon: "ri-road-map-line"
+                  icon: "fr-icon-road-map-line"
               },
               {
                   text: "Rechercher une donnée",
                   to: useBaseUrl() + '/rechercher-une-donnee/search',
-                  icon: "ri-search-line"
+                  icon: "fr-icon-search-line"
               },
               {
                   text: "Publier une donnée",
                   to: useBaseUrl() + '/publier-une-donnee',
-                  icon: "ri-database-line"
+                  icon: "fr-icon-database-line"
               },
               // {
               //     text: "Créer une carte",
@@ -83,12 +83,12 @@ export function useHeaderParams() {
             {
                 text: "Tableau de bord",
                 to: useBaseUrl() + '/tableau-de-bord',
-                icon: "ri-dashboard-3-line"
+                icon: "fr-icon-dashboard-3-line"
             },
             {
                 text: "Mon compte",
                 to: useBaseUrl() + '/mon-compte',
-                icon: "ri-user-line"
+                icon: "fr-icon-user-line"
             }
           ]   
         });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig, ProxyOptions, ViteDevServer } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import EnvRuntime from 'vite-plugin-env-runtime';
+import htmlPurge from 'vite-plugin-purgecss'
 
 // INFO 
 // mode https avec certificats unsecure (dev)
@@ -23,6 +24,10 @@ export default defineConfig({
   plugins: [
     vue(),
     vueJsx(),
+    htmlPurge({
+      safelist: [/^(?!fr-).*/], // safelist: ce qui ne commence pas par fr- (= purge les classes dsfr uniquement)
+      variables: true, // supprime les variables css inutilisées
+    }),
     // INFO mode https
     // basicSsl(),
     AutoImport({


### PR DESCRIPTION
**Modification du build pour réduire le poids du CSS final**
*Contexte: Après mise à jour du dsfr en 1.14.n, le poids du CSS final est passé de 1.6Mo à 2.1Mo.*

J'ai donc voulu essayer [purgecss](https://purgecss.com/), mais pour aller au plus simple pour l'instant, je l'ai configuré pour purger uniquement les classes dsfr (qui commencent par `fr-`) et les variables.
Résultat: le poids du CSS final est maintenant à ~310Ko (~75Ko en gzip) \o/

J'ai noté un seul soucis, lié aux icones du header, que j'ai modifié dans cette PR.
A tester de votre coté pour être sûr que rien d'autre n'est cassé...

A noter pour plus tard:
- les variables dsfr de themes ne sont pas toutes supprimées car utilisées comme ça `--bg:red;--bg-2:var(--bg);--hover:var(--bg-2)`

Quel type de changement cette Pull Request introduit-elle :
- [ ] Bugfix
- [ ] Feature
- [ ] Mise à jour du style du code (syntaxe, renommage de fonctions)
- [ ] Refactoring (lisibilité/performance du code, sans changements fonctionnels)
- [x] Changement sur le processus de build
- [ ] Contenu de la documentation
- [ ] Autres (décrire ci-après) : 