### PR TITLE
fix(SearchAdvanced): Utilise un placeholder plus court en mobile

### DIFF
--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -39,6 +39,9 @@ import CatalogManager from './control/CatalogManager.vue';
 import { useDomStore } from '@/stores/domStore';
 import { useMapStore } from "@/stores/mapStore";
 import { useControls, useControlsExtensionPosition } from '@/composables/controls';
+import { useMatchMedia } from '@/composables/matchMedia';
+let isMobile = useMatchMedia('SM');
+
 import { useLogger } from 'vue-logger-plugin';
 
 import IconGeolocationSVG from "../../assets/geolocation.svg";
@@ -90,23 +93,24 @@ const domStore = useDomStore();
 const log = useLogger();
 log.debug(props.controlOptions);
 
-
 // liste des options pour les contrôles
-const searchEngineOptions = {
-  id: "1",
-  collapsed: false,
-  collapsible: false,
-  returnTrueGeometry: true,
-  autocompleteOptions : {
-    serviceOptions : {
-        maximumResponses : 10
+const searchEngineOptions = computed(() => {
+  return {
+    id: "1",
+    collapsed: false,
+    collapsible: false,
+    returnTrueGeometry: true,
+    autocompleteOptions : {
+      serviceOptions : {
+          maximumResponses : 10
+      },
+      prettifyResults : true,
+      maximumEntries : 5
     },
-    prettifyResults : true,
-    maximumEntries : 5
-  },
-  markerUrl : IconGeolocationSVG,
-  placeholder: "Rechercher un lieu...",
-};
+    markerUrl : IconGeolocationSVG,
+    placeholder: isMobile.value ? 'Rechercher...' : 'Rechercher un lieu...',
+  };
+});
 
 const layerSwitcherOptions = {
   options: {

--- a/src/components/carte/control/SearchEngine.vue
+++ b/src/components/carte/control/SearchEngine.vue
@@ -49,7 +49,7 @@ const advancedSearchEngineOptions = computed(() => {
 });
 
 // const searchEngineAdvanced = ref(markRaw(new SearchEngineAdvanced(advancedSearchEngineOptions.value)));
-const searchEngineAdvanced = shallowRef(new SearchEngineAdvanced(advancedSearchEngineOptions.value));
+let searchEngineAdvanced = shallowRef(new SearchEngineAdvanced(advancedSearchEngineOptions.value));
 
 onMounted(() => {
   if (props.visibility) {
@@ -65,13 +65,13 @@ onMounted(() => {
 })
 
 onBeforeUpdate(() => {
-  if (!props.visibility) {
-    map.removeControl(searchEngineAdvanced.value);
-  }
+  map.removeControl(searchEngineAdvanced.value);
 })
 
 onUpdated(() => {
   if (props.visibility) {
+    // cree un nouveau searchengine quand les props changent (label)
+    searchEngineAdvanced = shallowRef(new SearchEngineAdvanced(advancedSearchEngineOptions.value));
     map.addControl(searchEngineAdvanced.value);
   }
 })


### PR DESCRIPTION
Gère le placeholder en mode mobile. Le texte "Rechercher un lieu..." devient "Rechercher..."

<img width="492" height="145" alt="image" src="https://github.com/user-attachments/assets/b554eee1-479e-4e96-8cd3-d329e652628e" />
<img width="329" height="154" alt="image" src="https://github.com/user-attachments/assets/d15f4e4e-f5a0-4ae4-ab6c-98738b0c5cfa" />

