### PR TITLE
Les panels des widgets de gauche sont sous la recherche (#1002)

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -51,6 +51,7 @@ Reset du localStorage pour les modifications de l'espace personnel.
   - Amélioration accessibilité toggle du header compact (#972)
   - UI : amélioration du comportement de l'interface aux valeurs seuils de taille d'écran (#971)
   - Territories: fixe la hauteur de la modale (#886)
+  - Panels: les panels des widgets de gauche sont positionnés sous la recherche (#1009)
 
 #### 🔒 [Sécurité]
 

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -719,6 +719,8 @@ onMounted(() => {
 .position-container-top-left .gpf-panel,
 .position-container-bottom-left .gpf-panel {
   left: $widget-btn-size + $gap !important;
+  top: $widget-btn-size + $gap !important;
+  max-height: calc(100cqb - $widget-btn-size - $gap * 3) !important;
 }
 .position-container-top-right .gpf-panel,
 .position-container-bottom-right .gpf-panel {

--- a/src/components/carte/control/ContextMenu.vue
+++ b/src/components/carte/control/ContextMenu.vue
@@ -49,7 +49,7 @@ const onContextMenuOpen = () => {
 @use "@/assets/variables" as *;
 
 .gpf-widget[id^="GPpointInfo-"] {
-  top: $gap;
+  top: $widget-btn-size + $gap * 2;
   left: $widget-panel-x;
 
   @include max(sm) {


### PR DESCRIPTION
Fixe #1009

Les panels des widgets de gauche, et ceux au clic droit, sont positionnés sous la recherche. La hauteur max est redéfinie également. Liste des panels:
- Légende
- Territories
- GetFeatureInfo
- adresse/coordonnées du point
- Signalement

<img width="599" height="586" alt="image" src="https://github.com/user-attachments/assets/f7c699a8-7cc4-4f47-bee8-2055d813b794" />
<img width="506" height="499" alt="image" src="https://github.com/user-attachments/assets/3a56fa45-97a1-41c6-93fe-0fa9933b80f0" />
<img width="511" height="397" alt="image" src="https://github.com/user-attachments/assets/b842b04a-e8bc-4d71-a78a-a8786e79ee97" />

 