### PR TITLE
Sauvegarder automatiquement (localStorage) le croquis lors de la fermeture de l'outil

### DIFF
--- a/src/components/carte/control/Drawing.vue
+++ b/src/components/carte/control/Drawing.vue
@@ -151,6 +151,16 @@ emitter.addEventListener("drawing:open:clicked", (e) => {
 });
 
 /**
+ * @event drawing:close
+ * @description Evenement pour fermer le controle de dessin
+ */
+emitter.addEventListener("drawing:close", () => {
+  if (drawing.value) {
+    drawing.value.setCollapsed(true);
+  }
+});
+
+/**
  * @event document:restore
  * @description Evenement pour restaurer un document temporaire déclenché 
  * par la demande de connexion réussie

--- a/src/components/carte/control/Drawing.vue
+++ b/src/components/carte/control/Drawing.vue
@@ -204,6 +204,30 @@ const restoreTemporaryDocument = (payload) => {
   });
 };
 
+const saveTemporaryDocument = (payload) => {
+  if (!payload) {
+    return;
+  }
+  if (!payload.type) {
+    var id = payload.layer.gpResultLayerId.toLowerCase();
+    var type = id.split(':')[0];
+    payload.type = type.replace("layer", ""); // ex. drawing, import, bookmark...
+  }
+  // stockage temporaire dans le localStorage
+  // car l'utilisateur demande une sauvegarde sans etre authentifié !
+  if (payload.layer) {
+    serviceStore.setAuthentificateSyncNeeded(true);
+    appStore.setDocumentTemporary(JSON.stringify({
+      content : payload.content,
+      name : payload.name,
+      description : payload.description,
+      format : payload.format,
+      target : payload.target,
+      type : payload.type
+    }));
+  }
+};
+
 onMounted(() => {
   log.debug("Drawing component mounted");
   if (props.visibility) {
@@ -268,13 +292,13 @@ onBeforeUpdate(() => {
 const onToggleShowVector = (e) => {
   log.debug(e);
   if (e.target.collapsed) {
-    if (drawing.value.getLayer()) {
-      onSaveVector({
+    if (!service.authenticated) {
+      saveTemporaryDocument({
         content : drawing.value.exportFeatures(),
         name : drawing.value.getExportName(),
         description : "",
         format : drawing.value.getExportFormat(),
-        layer : drawing.value.getLayer()
+        layer : drawing.value.getLayer(),
       });
     }
     // dissociation de la couche du widget 
@@ -341,17 +365,7 @@ const onSaveVector = (e) => {
   // stockage temporaire dans le localStorage
   // car l'utilisateur demande une sauvegarde sans etre authentifié !
   if (bSaveDocumentTemporary) {
-    if (data.layer) {
-      serviceStore.setAuthentificateSyncNeeded(true);
-      appStore.setDocumentTemporary(JSON.stringify({
-        content : data.content,
-        name : data.name,
-        description : data.description,
-        format : data.format,
-        target : data.target,
-        type : data.type
-      }));
-    }
+    saveTemporaryDocument(data);
     return; // pas plus loin...
   }
 

--- a/src/components/carte/control/Drawing.vue
+++ b/src/components/carte/control/Drawing.vue
@@ -268,6 +268,15 @@ onBeforeUpdate(() => {
 const onToggleShowVector = (e) => {
   log.debug(e);
   if (e.target.collapsed) {
+    if (drawing.value.getLayer()) {
+      onSaveVector({
+        content : drawing.value.exportFeatures(),
+        name : drawing.value.getExportName(),
+        description : "",
+        format : drawing.value.getExportFormat(),
+        layer : drawing.value.getLayer()
+      });
+    }
     // dissociation de la couche du widget 
     // pour permettre une autre saisie dans 
     // une autre couche

--- a/src/features/events.js
+++ b/src/features/events.js
@@ -42,16 +42,18 @@ var EVENTS = {
     "document:exported",
     "document:shared",
     "document:restore",
+    // others
+    "leftmenu:close",
+    "modalreporting:open:clicked",
     // widgets
     "catalog:open:clicked",
-    "leftmenu:close",
     "drawing:open:clicked",
+    "drawing:close",
     "layerimport:open:clicked",
     "searchengine:open:displayed",
     "searchengine:geolocation:clicked",
     "searchengine:geolocation:removed",
     "reporting:open:clicked",
-    "modalreporting:open:clicked",
     // edition
     "vector:edit:clicked",
     "mapbox:edit:clicked",


### PR DESCRIPTION
cf. issue #950 

Actuellement, un dessin est enregistré temporairement dans le localStorage si l'utilisateur est en mode hors ligne, et souhaite l'enregistrer dans son espace personnel.

Maintenant, on force l’enregistrement temporaire dans le localStorage d'un dessin en mode hors-ligne lors de la fermeture de l'outil de dessin sans lui demander son avis.

Une alerte est affichée.