### PR TITLE
Feat/988 modale embarquement

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -31,6 +31,7 @@ Reset du localStorage pour les modifications de l'espace personnel.
   - Territoires : les territoires personnalisés sont sauvegardés dans les données de session et donc conservés en rechargeant la page (#969)
   - SearcheEngine: ajout du placeholder "Rechercher un lieu" (#1010)
   - Amélioration des performances de rendu de la carte et de l’interface (#1007)
+  - Ajout d’une case à cocher «Ne plus afficher» sur la modale d’embarquement (#988)
 
 #### 🔥 [Obsolète]
 

--- a/src/components/CartoAndTools.vue
+++ b/src/components/CartoAndTools.vue
@@ -8,8 +8,6 @@ import ShareModal from "@/components/carte/control/ShareModal.vue";
 import PrintModal from "@/components/carte/control/PrintModal.vue";
 import SaveModal from "@/components/modals/ModalSave.vue";
 
-import ModalWelcome from "@/components/modals/ModalWelcome.vue";
-
 import { useDataStore } from "@/stores/dataStore"
 import { useMapStore } from "@/stores/mapStore"
 import { useLogger } from 'vue-logger-plugin';
@@ -29,12 +27,9 @@ const refModalShare = ref<InstanceType<typeof ShareModal> | null>(null);
 const refModalSave = ref<InstanceType<typeof SaveModal> | null>(null);
 const refModalPrint = ref<InstanceType<typeof PrintModal> | null>(null);
 
-const refModalWelcome = ref<InstanceType<typeof ModalWelcome> | null>(null);
-
 provide("refModalShare", refModalShare);
 provide("refModalLogin", refModalLogin);
 provide("refModalSave", refModalSave);
-provide("refModalWelcome", refModalWelcome);
 // Les gestionnaires d'évenements des modales
 const onModalShareOpen = () => {
   refModalShare.value.onModalShareOpen()
@@ -201,8 +196,6 @@ provide("selectedLayers", selectedLayers);
     <LoginModal ref="refModalLogin" />
     <SaveModal ref="refModalSave" />
     <PrintModal ref="refModalPrint" />
-    <!-- Modale : Welcome (+ Eulerian) -->
-    <ModalWelcome ref="refModalWelcome" />
   </div>
 </template>
 

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -6,10 +6,30 @@
     @close="onClose"
   >
     <slot />
+
+    <div
+      v-if="dismissible"
+      class="fr-mt-2v fr-ml-4v"
+    >
+      <DsfrCheckbox
+        v-model="askDismiss"
+        class="fr-mt-8w"
+        value="valeur 1"
+        name="checkbox-simple"
+        label="Ne plus afficher"
+        small
+        inline
+      />
+    </div>
   </DsfrModal>
 </template>
 
 <script setup>
+import { ref, onBeforeUnmount } from 'vue';
+
+import { useAppStore } from '@/stores/appStore';
+let appStore = useAppStore();
+
 import { useModals } from '@/composables/useModals';
 let modals = useModals();
 
@@ -26,9 +46,36 @@ let props = defineProps({
     type: String,
     default: 'md',
   },
+  dismissible: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 let onClose = () => {
   modals.close(props.name);
+
+  if (askDismiss.value) {
+    onDismiss(props.name);
+  }
 };
+
+// emet close juste avant la destruction du composant
+onBeforeUnmount(() => {
+  onClose();
+});
+
+// ne plus afficher ?
+let askDismiss = ref(false);
+// stocke les modales "ne plus afficher"
+let onDismiss = (modalName) => {
+  let dismissibleModals = [];
+  if (localStorage.getItem(appStore.ns('modals'))) {
+    dismissibleModals = JSON.parse(localStorage.getItem(appStore.ns('modals')));
+  }
+
+  // on push dans local storage (pas de vérification, car pas possible a priori)
+  dismissibleModals.push(modalName);
+  localStorage.setItem(appStore.ns('modals'), JSON.stringify(dismissibleModals));
+}
 </script>

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -74,8 +74,10 @@ let onDismiss = (modalName) => {
     dismissibleModals = JSON.parse(localStorage.getItem(appStore.ns('modals')));
   }
 
-  // on push dans local storage (pas de vérification, car pas possible a priori)
-  dismissibleModals.push(modalName);
+  // on push dans local storage (sans doublons)
+  if (!dismissibleModals.includes(modalName)) {
+    dismissibleModals.push(modalName);
+  }
   localStorage.setItem(appStore.ns('modals'), JSON.stringify(dismissibleModals));
 }
 </script>

--- a/src/components/modals/ModalWelcome.vue
+++ b/src/components/modals/ModalWelcome.vue
@@ -1,101 +1,36 @@
-<script setup lang="ts">
-// plugin local
-import { useBaseUrl } from '@/composables/baseUrl';
-// plugin local
-import { useEulerian } from '@/plugins/Eulerian';
-
-const eulerian = useEulerian();
-
-const welcomeModalOpened = ref(false);
-
-const openModalWelcome = () => {
-  welcomeModalOpened.value = true;
-  eulerian.pause();
-}
-
-const onWelcomeModalClose = () => {
-  welcomeModalOpened.value = false;
-  eulerian.resume();
-}
-
-defineExpose({
-  openModalWelcome,
-  onWelcomeModalClose
-});
-
-const size = "lg";
-
+<script setup>
 const logoText = "République Française";
 
 const iconProps = ref({ scale: 1.25, name: 'ri:map-2-line' });
-
-onMounted(() => {
-});
-
 </script>
 
 <template>
-  <!-- Modale : Paramètres d’affichage -->
-  <DsfrModal 
-    ref="modal"
-    title=""
-    :opened="welcomeModalOpened" 
-    :size="size" 
-    class="welcome-modal"
-    @close="onWelcomeModalClose"
-  >
-    <div class="fr-container">
-      <div class="fr-grid-row logo-row">
-        <DsfrLogo
-          :logo-text="logoText"
-          data-testid="header-logo"
-          class="maxwidth"
-        />
-        <img
-          src="https://data.geopf.fr/annexes/ressources/header/cartes-gouv-logo.svg"
-          alt=""
-        >
-      </div>
-      <div class="fr-grid-row content">
-        <h2>Bienvenue sur cartes.gouv.fr</h2>
-        <p>Retrouvez ici la référence de la cartographie publique pour explorer, connaître et piloter le territoire :</p>
-        <div><span class="icon vicon purple-glycine"><VIcon v-bind="iconProps" /></span>Accédez à une vaste bibliothèque de cartes et de données</div>
-        <div><span class="icon yellow-tournesol"><i class="fr-icon-brush-line" /></span>Créez et partagez vos propres cartes</div>
-        <div><span class="icon green-archipel"><i class="fr-icon-database-line" /></span>Hébergez vos données et vos cartes en toute autonomie</div>
-      </div>
-    </div>
-    <div class="fr-grid-row flex-end">
-      <DsfrButton 
-        secondary
+  <div class="fr-container">
+    <div class="fr-grid-row logo-row">
+      <DsfrLogo
+        :logo-text="logoText"
+        data-testid="header-logo"
+        class="maxwidth"
+      />
+      <img
+        src="https://data.geopf.fr/annexes/ressources/header/cartes-gouv-logo.svg"
+        alt=""
       >
-        <a :href="useBaseUrl() + '/decouvrir'">En savoir plus</a>
-      </DsfrButton>
-      <DsfrButton 
-        primary 
-        icon="fr-icon-arrow-right-s-line"
-        icon-right
-        @click="onWelcomeModalClose"
-      >
-        Accéder aux cartes
-      </DsfrButton>
     </div>
-  </DsfrModal>
+    <div class="fr-grid-row content">
+      <h2 class="fr-modal__title fr-h2">
+        Bienvenue sur cartes.gouv.fr
+      </h2>
+      <p>Retrouvez ici la référence de la cartographie publique pour explorer, connaître et piloter le territoire :</p>
+      <div><span class="icon vicon purple-glycine"><VIcon v-bind="iconProps" /></span>Accédez à une vaste bibliothèque de cartes et de données</div>
+      <div><span class="icon yellow-tournesol"><i class="fr-icon-brush-line" /></span>Créez et partagez vos propres cartes</div>
+      <div><span class="icon green-archipel"><i class="fr-icon-database-line" /></span>Hébergez vos données et vos cartes en toute autonomie</div>
+    </div>
+  </div>
 </template>
 <style scoped lang="scss">
-.welcome-modal {
-  z-index: 10000;
-}
-.fr-container {
-    padding-left: 3rem;
-    padding-right: 3rem;  
-}
 .maxwidth {
     max-width: 140px;
-}
-.flex-end {
-    justify-content: flex-end;
-    gap: 1rem;
-    margin-top: 1.5rem;
 }
 img {
     width: 4.5rem;
@@ -107,13 +42,8 @@ img {
     scale: 0.595;
     transform-origin: left;
 }
-.fr-container {
-    gap: 1.5rem;
-}
-.content {
-    div {
-        margin-bottom: 1rem;
-    }
+.content div {
+    margin-bottom: 1rem;
 }
 div > span {
     margin-right: 0.5rem;

--- a/src/components/modals/Modals.vue
+++ b/src/components/modals/Modals.vue
@@ -19,6 +19,31 @@
     >
       <ModalConsentCustom />
     </Modal>
+
+    <Modal
+      v-if="modals.isOpen('welcome')"
+      name="welcome"
+      size="lg"
+      title=""
+      dismissible
+      :actions="[
+        {
+          label: 'Accéder aux cartes',
+          onClick () {
+            modals.close('welcome')
+          },
+        },
+        {
+          label: 'En savoir plus',
+          secondary: true,
+          onClick () {
+            setUrl('/decouvrir');
+          },
+        },
+      ]"
+    >
+      <ModalWelcome />
+    </Modal>
   </div>
 </template>
 
@@ -26,7 +51,28 @@
 import Modal from '@/components/modals/Modal.vue';
 import ModalConsent from '@/components/modals/ModalConsent.vue';
 import ModalTheme from '@/components/modals/ModalTheme.vue';
+import ModalWelcome from '@/components/modals/ModalWelcome.vue';
 
+import { useAppStore } from '@/stores/appStore';
+let appStore = useAppStore();
+
+import { useBaseUrl } from '@/composables/baseUrl';
 import { useModals } from '@/composables/useModals';
 let modals = useModals();
+
+const setUrl = (url) => {
+  window.location.href = useBaseUrl() + url;
+};
+
+onMounted(() => {
+  // modale d'embarquement ?
+  // on verifie le localstorage, on ouvre si non inclus
+  let dismissibleModals = [];
+  if (localStorage.getItem(appStore.ns('modals'))) {
+    dismissibleModals = JSON.parse(localStorage.getItem(appStore.ns('modals')));
+  }
+  if (!dismissibleModals.includes('welcome')) {
+    modals.open('welcome');
+  }
+});
 </script>


### PR DESCRIPTION
Fix #988 
Ajoute une case à cocher «Ne plus afficher» sur la modale d'embarquement (l'info est stockée dans localstorage sous la clé `cartes.gouv.fr.modals`)

<img width="947" height="786" alt="image" src="https://github.com/user-attachments/assets/9b4c7289-649f-4e21-bbb4-a1c372a06e0e" />


Coté code:

- ajout d'une prop `dismissible` pour les modales (ajoute la case à cocher, et gère l'état dans localstorage)
- refacto: déplacement de la modale d'embarquement dans `Modals.vue` pour centralisation
- refacto: utilisation de la prop `actions` de vuedsfr sur `Modal.vue` pour les boutons d'actions
