### PR TITLE
Ajout de la variable d'environnement VITE_GPF_BASE_URL_SERVICE pour les services de données

### DIFF
--- a/env/.env.demo
+++ b/env/.env.demo
@@ -6,9 +6,12 @@ VITE_GPF_CONF_TERRITORIES="data/territories.json"
 
 VITE_GPF_BASE_URL_EXTERNAL="https://cartes.gouv.fr"
 VITE_GPF_BASE_URL_DOCUMENT="https://data.geopf.fr/documents/"
+VITE_GPF_BASE_URL_SERVICE="https://data.geopf.fr"
 
+# utilisation du service de données statiques de cartes.gouv.fr
 VITE_GPF_SERVICE_STATIC="true"
 
+# utilisation du service d'anomalies de geoportail.gouv.fr
 VITE_GPF_SERVICE_ANOMALY="https://www.geoportail.gouv.fr/wp-json/wp/v2"
 
 # mock (orienté dev)

--- a/env/.env.development
+++ b/env/.env.development
@@ -6,9 +6,12 @@ VITE_GPF_CONF_TERRITORIES="data/territories.json"
 
 VITE_GPF_BASE_URL_EXTERNAL="https://cartes.mut-dev.ign.fr"
 VITE_GPF_BASE_URL_DOCUMENT="https://data-qua.priv.geopf.fr/documents/"
+VITE_GPF_BASE_URL_SERVICE="https://data.geopf.fr"
 
+# utilisation du service de données statiques de cartes.gouv.fr
 VITE_GPF_SERVICE_STATIC="true"
 
+# utilisation du service d'anomalies de geoportail.gouv.fr
 VITE_GPF_SERVICE_ANOMALY="https://geoportail.dev.ign-mut.ovh/wp-json/wp/v2"
 
 # mock (orienté dev)

--- a/env/.env.development-local
+++ b/env/.env.development-local
@@ -6,9 +6,12 @@ VITE_GPF_CONF_TERRITORIES="data/territories.json"
 
 VITE_GPF_BASE_URL_EXTERNAL="http://localhost:5173"
 VITE_GPF_BASE_URL_DOCUMENT="https://data.geopf.fr/documents/"
+VITE_GPF_BASE_URL_SERVICE="https://data-pprd.priv.geopf.fr"
 
+# utilisation du service de données statiques de cartes.gouv.fr
 VITE_GPF_SERVICE_STATIC="true"
 
+# utilisation du service d'anomalies de geoportail.gouv.fr
 VITE_GPF_SERVICE_ANOMALY="https://www.geoportail.gouv.fr/wp-json/wp/v2"
 
 # mock (orienté dev)

--- a/env/.env.docker-local
+++ b/env/.env.docker-local
@@ -6,9 +6,12 @@ VITE_GPF_CONF_TERRITORIES="data/territories.json"
 
 VITE_GPF_BASE_URL_EXTERNAL="http://localhost:1235"
 VITE_GPF_BASE_URL_DOCUMENT="https://data.geopf.fr/documents/"
+VITE_GPF_BASE_URL_SERVICE="https://data.geopf.fr"
 
+# utilisation du service de données statiques de cartes.gouv.fr
 VITE_GPF_SERVICE_STATIC="true"
 
+# utilisation du service d'anomalies de geoportail.gouv.fr
 VITE_GPF_SERVICE_ANOMALY="https://www.geoportail.gouv.fr/wp-json/wp/v2"
 
 # mock (orienté dev)

--- a/env/.env.production
+++ b/env/.env.production
@@ -6,9 +6,12 @@ VITE_GPF_CONF_TERRITORIES="data/territories.json"
 
 VITE_GPF_BASE_URL_EXTERNAL="https://cartes.gouv.fr"
 VITE_GPF_BASE_URL_DOCUMENT="https://data.geopf.fr/documents/"
+VITE_GPF_BASE_URL_SERVICE="https://data.geopf.fr"
 
+# utilisation du service de données statiques de cartes.gouv.fr
 VITE_GPF_SERVICE_STATIC="true"
 
+# utilisation du service d'anomalies de geoportail.gouv.fr
 VITE_GPF_SERVICE_ANOMALY="https://www.geoportail.gouv.fr/wp-json/wp/v2"
 
 # mock (orienté dev)

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -93,6 +93,13 @@ const domStore = useDomStore();
 const log = useLogger();
 log.debug(props.controlOptions);
 
+var baseUrlService = import.meta.env.VITE_GPF_BASE_URL_SERVICE;
+if (!baseUrlService) {
+  // Utilisation de l'url des services de production
+  log.warn("VITE_GPF_BASE_URL_SERVICE is not defined, using production URL");
+  baseUrlService = "https://data.geopf.fr";
+}
+
 // liste des options pour les contrôles
 const searchEngineOptions = computed(() => {
   return {
@@ -102,10 +109,16 @@ const searchEngineOptions = computed(() => {
     returnTrueGeometry: true,
     autocompleteOptions : {
       serviceOptions : {
-          maximumResponses : 10
+          maximumResponses : 10,
+          serverUrl : `${baseUrlService}/geocodage/completion?`
       },
       prettifyResults : true,
       maximumEntries : 5
+    },
+    geocodeOptions : {
+      serviceOptions : {
+        serverUrl : `${baseUrlService}/geocodage/search`
+      }
     },
     markerUrl : IconGeolocationSVG,
     placeholder: isMobile.value ? 'Rechercher...' : 'Rechercher un lieu...',
@@ -195,6 +208,9 @@ const reverseGeocodeOptions = {
   position: useControlsExtensionPosition().reverseGeocodeOptions,
   gutter: false,
   listable: true,
+  reverseGeocodeOptions : {
+    serverUrl : `${baseUrlService}/geocodage/reverse`
+  }
 };
 
 const isocurveOptions = {
@@ -202,6 +218,9 @@ const isocurveOptions = {
   id: "13",
   gutter: false,
   listable: true,
+  isocurveOptions : {
+    serverUrl : `${baseUrlService}/navigation/isocurve`
+  }
 };
 
 const routeOptions = {
@@ -210,6 +229,9 @@ const routeOptions = {
   gutter: false,
   listable: true,
   prettifyCompute: true,
+  routeOptions : {
+    serverUrl : `${baseUrlService}/navigation/itineraire`
+  }
 };
 
 const measureLengthOptions = {
@@ -239,6 +261,11 @@ const mousePositionOptions = {
   gutter: false,
   listable: true,
   editCoordinates : true,
+  altitude : {
+    serviceOptions : {
+      serverUrl : `${baseUrlService}/altimetrie/1.0/calcul/alti/rest/elevation.json?`
+    }
+  },
   // On ajoute les systemes UTM pour les territoires
   systems : [
     {
@@ -384,6 +411,9 @@ const elevationPathOptions = {
   position: useControlsExtensionPosition().elevationPathOptions,
   gutter: false,
   listable: true,
+  elevationPathOptions : {
+    serverUrl : `${baseUrlService}/altimetrie/1.0/calcul/alti/rest/elevationLine.json`
+  }
 };
 
 const layerImportOptions = {


### PR DESCRIPTION
cf. PR #1034 

---

Cette PR permet de mettre à disposition la variable d'environnement suivante : 
→`VITE_GPF_BASE_URL_SERVICE` : permet de surcharger les urls des services pour les widgets qui les utilisent

Cette variable permet ainsi de configurer les différents environnements de déploiement (dev, qualif, pprod, prod).

---

Ex.
```ini
VITE_GPF_BASE_URL_SERVICE="https://data-pprd.priv.geopf.fr"
```

```js
var baseUrlService = import.meta.env.VITE_GPF_BASE_URL_SERVICE;
if (!baseUrlService) {
  // Utilisation de l'url des services de production
  log.warn("VITE_GPF_BASE_URL_SERVICE is not defined, using production URL");
  baseUrlService = "https://data.geopf.fr";
}

const reverseGeocodeOptions = {
  id: "12",
  position: useControlsExtensionPosition().reverseGeocodeOptions,
  gutter: false,
  listable: true,
  reverseGeocodeOptions : {
    serverUrl : `${baseUrlService}/geocodage/reverse`
  }
};

const reverseGeocode = new ReverseGeocode(reverseGeocodeOptions);
```