### PR TITLE
Fix: overflow et largeur panels

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -35,6 +35,7 @@ Corrections UI variées, amélioration de certaines performances de rendu.
   - Cartalogue : correction du scoll en mode mobile (#1008)
   - Panels: les panels des widgets de gauche sont positionnés sous la recherche (#1015)
   - Panels: fixe un scroll sur la légende
+  - Panels: fixe la largeur du sous panel Infos de LayerSwitcher
   - Espace Personnel : Les dessin sont conservés dans le localStorage quand on ferme le widget de dessin et non perdus en mode déconnecté (#1019)
   - Itinéraire/Isochrone(HOTFIX) : répare l'interface des widgets itinéraire et isochrone
   

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -34,6 +34,7 @@ Corrections UI variées, amélioration de certaines performances de rendu.
   - LayerSwitcher : la largeur des panel est forcée (#1008)
   - Cartalogue : correction du scoll en mode mobile (#1008)
   - Panels: les panels des widgets de gauche sont positionnés sous la recherche (#1015)
+  - Panels: fixe un scroll sur la légende
   - Espace Personnel : Les dessin sont conservés dans le localStorage quand on ferme le widget de dessin et non perdus en mode déconnecté (#1019)
   - Itinéraire/Isochrone(HOTFIX) : répare l'interface des widgets itinéraire et isochrone
   

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -34,10 +34,10 @@ Corrections UI variées, amélioration de certaines performances de rendu.
   - LayerSwitcher : la largeur des panel est forcée (#1008)
   - Cartalogue : correction du scoll en mode mobile (#1008)
   - Panels: les panels des widgets de gauche sont positionnés sous la recherche (#1015)
-  - Panels: fixe un scroll sur la légende
-  - Panels: fixe la largeur du sous panel Infos de LayerSwitcher
   - Espace Personnel : Les dessin sont conservés dans le localStorage quand on ferme le widget de dessin et non perdus en mode déconnecté (#1019)
   - Itinéraire/Isochrone(HOTFIX) : répare l'interface des widgets itinéraire et isochrone
+  - Panels(HOTFIX): fixe un scroll sur la légende (#1041)
+  - Panels(HOTFIX): fixe la largeur du sous panel Infos de LayerSwitcher (#1041)
   
 #### 🔒 [Sécurité]
 

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -767,9 +767,6 @@ onMounted(() => {
 .gpf-panel__body_ls {
   max-height: initial !important;
 }
-.gpf-panel__content {
-  overflow: auto;
-}
 @include max(sm) {
   .gpf-panel {
     max-width: 100vw !important;

--- a/src/components/carte/control/LayerSwitcher.vue
+++ b/src/components/carte/control/LayerSwitcher.vue
@@ -554,12 +554,17 @@ const onClickEditLayer = (e) => {
 .gpf-panel[id^="GPlayersList"] ~ .gpf-panel {
   right: calc(($widget-panel-width-lg - $widget-panel-multiple-width-lg) / 2) + $widget-btn-size + $gap !important;
   top: 4rem !important;
-  min-width: $widget-panel-multiple-width-lg !important;
-  max-width: $widget-panel-multiple-width-lg !important;
+  width: $widget-panel-multiple-width-lg;
+  max-width: min($widget-panel-multiple-width-lg, calc(100cqi - $widget-btn-size * 2 - $gap * 4 - ($widget-panel-width-lg - $widget-panel-multiple-width-lg))) !important;
 }
 // utilise un fond clair dans le panel
 .gpf-panel__content[id^="GPlayerSwitcher_ID_"][aria-current="true"],
 .gpf-panel__content[id^="GPlayerSwitcher_ID_"]:hover {
   background: var(--background-default-grey);
+}
+// panels spécifiques
+div[id^="GPlayerInfoContent"] {
+  width: initial;
+  padding: 10px;
 }
 </style>


### PR DESCRIPTION
Fix 2 soucis détectés:

1. Scroll bizarre sur la légende
J'avais ajouté un overflow par défaut sur tous les panels. Ce qui ajoutait un scroll dans la légende.
En l'enlevant, je ne vois rien de cassé, mais à bien revérifier.

Avant
<img width="399" height="202" alt="image" src="https://github.com/user-attachments/assets/58effede-6120-478d-a187-e4d10ffb1979" />

2. Fixe la largeur du sous panel Infos de LayerSwitcher

Avant
<img width="616" height="394" alt="image" src="https://github.com/user-attachments/assets/2cc3d797-b663-4133-8e9d-c3d3629bafbb" />
<img width="616" height="394" alt="image" src="https://github.com/user-attachments/assets/e20c3c04-8081-4644-8629-b3e2369a4c65" />


Après
<img width="722" height="464" alt="image" src="https://github.com/user-attachments/assets/4edc6c43-1e17-47a1-87e2-3dc19221b7d1" />
<img width="534" height="500" alt="image" src="https://github.com/user-attachments/assets/568e8750-4693-4de0-9be1-d52e5cba8358" />
