### PR TITLE
Désactiver la reactivité du localStockage pour les layers, bookmarks et controls

### DIFF
--- a/src/stores/mapStore.js
+++ b/src/stores/mapStore.js
@@ -119,7 +119,9 @@ export const useMapStore = defineStore('map', () => {
       // on nettoie le localStorage pour ne pas conserver de valeurs obsolètes
       Object.keys(localStorage).forEach(function(key) {
         if (key.startsWith(NAMESPACE)) {
-          localStorage.removeItem(key);
+          // FIXME si on a plusieurs onglets ouverts sur un même navigateur,
+          // la suppression du localStorage est répercutée sur tous les onglets !
+          // localStorage.removeItem(key);
         }
       });
     }

--- a/src/stores/mapStore.js
+++ b/src/stores/mapStore.js
@@ -292,7 +292,7 @@ export const useMapStore = defineStore('map', () => {
    * La liste des couches
    * ex. ORTHOIMAGERY.ORTHOPHOTOS$GEOPORTAIL:OGC:WMTS(1;1;0)
    */
-  var layers = useStorage(ns('layers'), DEFAULT.LAYERS);
+  var layers = useStorage(ns('layers'), DEFAULT.LAYERS, localStorage, { listenToStorageChanges: false });
   if (!layers.value) {
     var l = DEFAULT.LAYERS.split(",").filter(function (l) {
       return !!l;
@@ -312,7 +312,7 @@ export const useMapStore = defineStore('map', () => {
    * La liste des contrôles
    * ex. Isocurve(1)
    */
-  var controls = useStorage(ns('controls'), DEFAULT.CONTROLS);
+  var controls = useStorage(ns('controls'), DEFAULT.CONTROLS, localStorage, { listenToStorageChanges: false });
   if (!controls.value) {
     var c = DEFAULT.CONTROLS.split(",").filter(function (c) {
       return !!c;
@@ -334,7 +334,7 @@ export const useMapStore = defineStore('map', () => {
    *    visible=1&
    *    grayscale=0
    */
-  var bookmarks = useStorage(ns('bookmarks'), "");
+  var bookmarks = useStorage(ns('bookmarks'), "", localStorage, { listenToStorageChanges: false });
   if (!bookmarks.value) {
     bookmarks.value = "";
   } else {


### PR DESCRIPTION
1. Désactiver la reactivité du localStockage pour les layers, bookmarks et controls sur l'écoute des changements sur d'autres onglets du navigateur.

2. Désactiver la suppression du localStorage lors d'un chargement d'un permalien pour éviter des effets indésirables sur plusieurs onglets.
