### PR TITLE
Fix sur la liste de sécurité pour préserver des classes et sélecteurs spécifiques lors de l'optimisation CSS

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,11 @@ export default defineConfig({
     vue(),
     vueJsx(),
     htmlPurge({
-      safelist: [/^(?!fr-).*/], // safelist: ce qui ne commence pas par fr- (= purge les classes dsfr uniquement)
+      safelist: [
+        /^(?!fr-).*/,  // safelist: ce qui ne commence pas par fr- (= purge les classes dsfr uniquement)
+        /^fr-btn--/,   // préserver toutes les classes fr-btn-- (utilisées par DsfrShare avec ::before/::after)
+        /^fr-.+::/,    // préserver les sélecteurs avec pseudo-éléments
+      ],
       variables: true, // supprime les variables css inutilisées
     }),
     // INFO mode https


### PR DESCRIPTION
On élargie la liste de sécurité pour préserver des classes et sélecteurs spécifiques lors de l'optimisation CSS.
Ceci permet de ne pas nettoyer les sélecteurs sur les réseaux sociaux du composant DSFR **DsfrShare**.

La taille de la CSS passe de `576K --> 609K`