### PR TITLE
fix(layerswitcher): ajout de la conf pour afficher les tooltips

### DIFF
--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -134,7 +134,8 @@ const layerSwitcherOptions = {
     panel: true,
     counter: true,
     allowEdit: true,
-    allowGrayScale: true
+    allowGrayScale: true,
+    allowTooltips: true
   }
 };
 


### PR DESCRIPTION


## Quel est le comportement actuel (avant PR) :
<!-- Décrire le comportement actuel qui est modifié, pourquoi il est modifié et, eventuellement, citer des tickets concernés -->

Numéro du ticket : alternative à la PR #1054 pour le fix du #1022

## Quel est le nouveau comportement :

On garde l'affichage de la description au survol, mais on affiche correctement la tooltip avec du HTML interprété via l'option du layerswitcher prévue à cet effet.

Le contenu de la tooltip est de fait moins long, surtout en cas de lien présent : 
AVANT : 
<img width="747" height="731" alt="image" src="https://github.com/user-attachments/assets/57a672ac-b729-4815-aa94-9baa35c70525" />

"\<a href="https://mon-super-lien/chemin/vers/la/page.html" > Super lien de la documentaton de la couche \</a>"

MAINTENANT 
<img width="607" height="801" alt="image" src="https://github.com/user-attachments/assets/0a07f9b3-8d88-4271-9b42-d30ec26df748" />


"<a href="https://mon-super-lien/chemin/vers/la/page.html">Super lien de la documentaton de la couche </a>"
## Cette PR introduit-elle des breaking changes ?

- [ ] Oui
- [x] Non

<!-- Si Oui, décrire l'impact et la marche à suivre pour adapter les applications existantes à ces BC. -->


## Autres informations

<!-- Autres informations importantes concernant cette PR comme la liste des tickets concernés, ou des screenshots qui illustrent les changements introduits par cette PR. -->
