### PR TITLE
Corrections UI

### DIFF
--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -22,6 +22,8 @@
 
 #### 🐛 [Correction]
 
+- UI extensions: fixe la position d'un panel dans un panel (#1078)
+
 #### 🔒 [Sécurité]
 
 ---

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -23,6 +23,7 @@
 #### 🐛 [Correction]
 
 - UI extensions: fixe la position d'un panel dans un panel (#1078)
+- UI: empêche le décalage de la page au focus clavier
 
 #### 🔒 [Sécurité]
 

--- a/DRAFT_CHANGELOG.md
+++ b/DRAFT_CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - UI extensions: fixe la position d'un panel dans un panel (#1078)
 - UI: empêche le décalage de la page au focus clavier
+- UI: masque le badge en mobile
 
 #### 🔒 [Sécurité]
 

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -866,6 +866,6 @@ onMounted(() => {
 
 // on décale tous les widgets qui dépassent de la hauteur (pour les masquer)
 .position-container-top-right > .gpf-widget-button:not([id^="GPcontrolList-"]) {
-  margin-left: calc(max(var(--i) - var(--nb-widgets), 0) * 2in);
+  margin-left: calc(max(var(--i) - var(--nb-widgets), 0) * -99in);
 }
 </style>

--- a/src/components/carte/Controls.vue
+++ b/src/components/carte/Controls.vue
@@ -779,6 +779,12 @@ onMounted(() => {
 .position-container-bottom-right .gpf-panel {
   right: $widget-btn-size + $gap !important;
 }
+// fixe position d'un panel dans un panel
+.gpf-panel .gpf-panel {
+  left: 0 !important;
+  top: 0 !important;
+  box-shadow: none;
+}
 .gpf-panel__body {
   max-height: calc(70vh) !important;
   max-height: calc(100cqb - $gap * 2) !important;

--- a/src/components/header/CustomHeader.vue
+++ b/src/components/header/CustomHeader.vue
@@ -146,6 +146,11 @@ headerParams.value.quickLinks = [
       content: none;
     }
   }
+  @include max(sm) {
+    .fr-header__service-title .fr-badge {
+      display: none;
+    }
+  }
 }
 
 // hack vuedsfr

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -142,6 +142,7 @@ body.modal-open {
 }
 .Map {
   grid-row: map;
+  min-height: min(75vh, 500px); // hauteur minimum (utile quand footer ouvert)
 }
 .CustomFooter {
   grid-row: footer;


### PR DESCRIPTION
- Fixe l'issue #1078 (CSS d'un panel dans un panel)
- Ajoute une hauteur minimale à la map (qui évite une carte trop petite quand le footer est ouvert)
- Empêche le décalage du site au focus clavier sur les outils (cf. capture Teams 28/05/2026 14:33)
- Masque le badge du header en mobile