### PR TITLE
Mise à jour des URLs de base pour les ressources statiques

### DIFF
--- a/env/.env.development-local
+++ b/env/.env.development-local
@@ -4,7 +4,7 @@ VITE_GPF_CONF_ALERTS="data/alerts.json"
 VITE_GPF_CONF_ENTREE_CARTO="data/entreeCarto.json"
 VITE_GPF_CONF_TERRITORIES="data/territories.json"
 
-VITE_GPF_BASE_URL_EXTERNAL="http://localhost:5173"
+VITE_GPF_BASE_URL_EXTERNAL="https://cartes.gouv.fr"
 VITE_GPF_BASE_URL_DOCUMENT="https://data.geopf.fr/documents/"
 VITE_GPF_BASE_URL_SERVICE="https://data.geopf.fr"
 

--- a/src/components/header/CustomHeader.vue
+++ b/src/components/header/CustomHeader.vue
@@ -2,18 +2,20 @@
 import { useDomStore } from "@/stores/domStore";
 import { useHeaderParams } from '@/composables/headerParams';
 import { useMatchMedia } from '@/composables/matchMedia';
+import { useBaseUrl } from '@/composables/baseUrl';
 import { CgfrFooter } from 'cartes.gouv.fr-vue-components';
 import CustomNavigation from '@/components/header/CustomNavigation.vue';
 
 const isStaticService = import.meta.env.VITE_GPF_SERVICE_STATIC === "true";
 
+const baseUrl = useBaseUrl();
 const domStore = useDomStore();
 const { theme } = useScheme();
 const mobileScreen = useMatchMedia('LG');
 
 let operatorImgSrc = computed(() => {
   let lightOrDark = theme.value === 'light' ? '' : '-dark';
-  return isStaticService ? `https://cartes.gouv.fr/img/header/cartes-gouv-logo${lightOrDark}.svg` : `https://data.geopf.fr/annexes/ressources/header/cartes-gouv-logo${lightOrDark}.svg`;
+  return isStaticService ? `${baseUrl}/img/header/cartes-gouv-logo${lightOrDark}.svg` : `${baseUrl}/annexes/ressources/header/cartes-gouv-logo${lightOrDark}.svg`;
 });
 
 const headerParams = useHeaderParams();

--- a/src/components/modals/ModalWelcome.vue
+++ b/src/components/modals/ModalWelcome.vue
@@ -1,6 +1,8 @@
 <script setup>
+import { useBaseUrl } from '@/composables/baseUrl';
 const isStaticService = import.meta.env.VITE_GPF_SERVICE_STATIC === "true";
 
+const baseUrl = useBaseUrl();
 const logoText = "République Française";
 const iconProps = ref({ scale: 1.25, name: 'ri:map-2-line' });
 </script>
@@ -14,7 +16,7 @@ const iconProps = ref({ scale: 1.25, name: 'ri:map-2-line' });
         class="maxwidth"
       />
       <img
-        :src="isStaticService ? 'https://cartes.gouv.fr/img/header/cartes-gouv-logo.svg' : 'https://data.geopf.fr/annexes/ressources/header/cartes-gouv-logo.svg'"
+        :src="isStaticService ? `${baseUrl}/img/header/cartes-gouv-logo.svg` : `${baseUrl}/annexes/ressources/header/cartes-gouv-logo.svg`"
         alt=""
       >
     </div>

--- a/src/composables/footerParams.js
+++ b/src/composables/footerParams.js
@@ -7,7 +7,7 @@ import { useBaseUrl } from '@/composables/baseUrl';
 export function useFooterParams() {
 
     const isStaticService = import.meta.env.VITE_GPF_SERVICE_STATIC === "true";
-
+    
     // Paramètres pour le Footer
     const footerParams = {
         beforeMandatoryLinks: [
@@ -49,23 +49,23 @@ export function useFooterParams() {
             title: "Nos partenaires",
             mainPartner: {
               href: "https://www.ign.fr/",
-              logo: isStaticService ? "https://cartes.gouv.fr/img/footer/partenaires/ign.png" : "https://data.geopf.fr/annexes/ressources/footer/ign.png",
+              logo: isStaticService ? useBaseUrl() + '/img/footer/partenaires/ign.png' : useBaseUrl() + '/annexes/ressources/footer/ign.png',
               name: "IGN"
           },
             subPartners: [
                 {
                     href: "https://www.transformation.gouv.fr/",
-                    logo: isStaticService ? "https://cartes.gouv.fr/img/footer/partenaires/min_fp.jpg" : "https://data.geopf.fr/annexes/ressources/footer/min_fp.jpg",
+                    logo: isStaticService ? useBaseUrl() + '/img/footer/partenaires/min_fp.jpg' : useBaseUrl() + '/annexes/ressources/footer/min_fp.jpg',
                     name: "Ministère de la transformation et de la fonction publiques"
                 },
                 {
                     href: "https://www.ecologie.gouv.fr/",
-                    logo: isStaticService ? "https://cartes.gouv.fr/img/footer/partenaires/min_ecologie.jpg" : "https://data.geopf.fr/annexes/ressources/footer/min_ecologie.jpg",
+                    logo: isStaticService ? useBaseUrl() + '/img/footer/partenaires/min_ecologie.jpg' : useBaseUrl() + '/annexes/ressources/footer/min_ecologie.jpg',
                     name: "Ministère de la Transition Écologique et de la Cohésion des Territoires"
                 },
                 {
                     href: "https://cnig.gouv.fr/",
-                    logo: isStaticService ? "https://cartes.gouv.fr/img/footer/partenaires/logo-rf-cnig.jpg" : "https://data.geopf.fr/annexes/ressources/footer/rf_cnig.jpg",
+                    logo: isStaticService ? useBaseUrl() + '/img/footer/partenaires/logo-rf-cnig.jpg' : useBaseUrl() + '/annexes/ressources/footer/rf_cnig.jpg',
                     name: "Conseil national de l’information géolocalisée"
                 },
             ]


### PR DESCRIPTION
cf. issue #1097 

On utilise pour le service _statique_ ou _annexe_ : 
```js
import { useBaseUrl } from '@/composables/baseUrl';
useBaseUrl()
```
cad la variable `import.meta.env.VITE_GPF_BASE_URL_EXTERNAL`